### PR TITLE
Align Cloud Run tfvars with runbook guidance

### DIFF
--- a/Programing/.env.example
+++ b/Programing/.env.example
@@ -1,0 +1,6 @@
+# Environment variables for the LLMHIVE FastAPI application
+# The default database uses SQLite for local development. Uncomment the Postgres
+# example when running against an external database such as Cloud SQL.
+API_TITLE=LLMHIVE API
+DATABASE_URL=sqlite:///./llmhive.db
+# DATABASE_URL=postgresql+psycopg2://llmhive:llmhive@db:5432/llmhive

--- a/Programing/Dockerfile
+++ b/Programing/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Programing/README.md
+++ b/Programing/README.md
@@ -1,0 +1,245 @@
+# LLMHIVE FastAPI Service
+
+This project bundles a lightweight FastAPI application together with all of the
+artifacts required to deploy it locally, to Google Kubernetes Engine (GKE)
+Autopilot by way of Helm, and to Cloud Run through Terraform automation. The
+goal of this repository is to act as a complete reference implementation so
+that an environment can be reproduced with minimal guesswork.
+
+## Repository layout
+
+```
+Programing/
+├── app/                      # FastAPI application package
+│   ├── api/                  # Example API router
+│   ├── config.py             # Centralised environment configuration
+│   ├── database.py           # SQLAlchemy session helpers
+│   └── main.py               # FastAPI entrypoint (uvicorn app.main:app)
+├── alembic/                  # Database migration environment
+│   └── versions/             # Example migration scripts
+├── deploy/
+│   ├── helm/llmhive/         # Helm chart for the Kubernetes deployment
+│   └── cloudrun/terraform/   # Terraform for Cloud Run rollout
+├── Dockerfile                # Container build recipe for the app
+├── docker-compose.yml        # Local Compose stack with Postgres
+├── pyproject.toml            # Project metadata and dependencies
+└── README.md                 # This documentation
+```
+
+## Key configuration files
+
+The table below explains the deployment files that commonly need adjusting
+before a production rollout.
+
+| File | Purpose | Notes |
+| ---- | ------- | ----- |
+| `Dockerfile` | Builds the service image with FastAPI and Alembic installed. | Exposes port 8000 for uvicorn and copies the migration assets. |
+| `docker-compose.yml` | Runs the API alongside a local Postgres instance. | The app receives `DATABASE_URL` pointing at the Compose database and still honours `.env` overrides. |
+| `.env.example` | Template for local environment variables. | Defaults to SQLite for quick starts and documents the Postgres connection string used by Compose or Cloud SQL. |
+| `deploy/helm/llmhive/values.yaml` | Baseline Helm defaults. | Suitable for local testing against SQLite. |
+| `deploy/helm/llmhive/values-prod.yaml` | GKE production overrides. | Supply Artifact Registry coordinates, ingress host, and Workload Identity values here. |
+| `deploy/helm/llmhive/templates/external-secret.yaml` | External Secrets Operator manifest. | Pulls the database URL from Google Secret Manager when `useExternalSecret` is enabled. |
+| `deploy/helm/llmhive/templates/serviceaccount.yaml` | Workload Identity service account. | Annotates the Kubernetes ServiceAccount with the mapped Google Service Account. |
+| `deploy/cloudrun/terraform/main.tf` | Cloud Run infrastructure as code. | Creates the service, binds IAM permissions, attaches a VPC connector, and maps a custom domain. |
+| `deploy/cloudrun/terraform/env.example.auto.tfvars` | Terraform variable template. | Copy to `env.auto.tfvars` and fill in project specific values including the secret name containing `DATABASE_URL`. |
+
+## Local development runbook (SQLite or Docker Compose)
+
+### Prerequisites
+
+* Python 3.11+
+* Optional: Docker and Docker Compose v2 for container-based workflows
+
+### Steps
+
+1. **Create a virtual environment and install dependencies**
+
+   ```bash
+   cd Programing
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -U pip
+   pip install -e .
+   ```
+
+2. **Configure environment variables**
+
+   ```bash
+   cp .env.example .env
+   # Optionally switch to Postgres by uncommenting the DATABASE_URL line
+   ```
+
+3. **Apply migrations (if the schema changes)**
+
+   ```bash
+   alembic upgrade head
+   ```
+
+4. **Start the API**
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+   The service listens on `http://127.0.0.1:8000`. Visit `/docs` for the
+   interactive API explorer or `/healthz` for a simple health probe.
+
+5. **Alternative: run via Docker Compose**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Compose will build the application image, start Postgres, and publish the
+   API on port 8000 using the Postgres connection string defined in the stack.
+   The `.env` file is still honoured so you can layer additional settings.
+
+## GKE Autopilot runbook (Helm + External Secrets)
+
+This path deploys the API to a GKE Autopilot cluster while sourcing the
+`DATABASE_URL` from Google Secret Manager through the External Secrets
+Operator (ESO).
+
+1. **Ensure cluster access**
+   * Provision or reuse an Autopilot cluster (`gcloud container clusters create-auto`).
+   * Fetch credentials using `gcloud container clusters get-credentials`.
+
+2. **Build and push the container image**
+
+   ```bash
+   docker build -t <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/llmhive_fastapi:<IMAGE_TAG> .
+   gcloud auth configure-docker <REGION>-docker.pkg.dev
+   docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/llmhive_fastapi:<IMAGE_TAG>
+   ```
+
+3. **Prepare Cloud SQL**
+   * Create a PostgreSQL instance with a private IP in the same VPC as the cluster.
+   * Create the database and application user.
+
+4. **Seed the Secret Manager secret**
+
+   ```bash
+   gcloud secrets create llmhive_database_url --replication-policy="automatic"
+   echo -n "postgresql+psycopg2://<DB_USER>:<DB_PASS>@<CLOUDSQL_PRIVATE_IP>:5432/<DB_NAME>" \
+     | gcloud secrets versions add llmhive_database_url --data-file=-
+   ```
+
+5. **Configure Workload Identity**
+   * Create a Google Service Account (GSA) such as `llmhive-app-gsa`.
+   * Grant it `roles/secretmanager.secretAccessor` and `roles/cloudsql.client`.
+   * Bind the Kubernetes ServiceAccount specified in `values-prod.yaml` to the GSA:
+
+     ```bash
+     gcloud iam service-accounts add-iam-policy-binding \
+       llmhive-app-gsa@<PROJECT_ID>.iam.gserviceaccount.com \
+       --role roles/iam.workloadIdentityUser \
+       --member "serviceAccount:<PROJECT_ID>.svc.id.goog[<NAMESPACE>/llmhive-app]"
+     ```
+
+6. **Install the External Secrets Operator (once per cluster)**
+
+   ```bash
+   helm repo add external-secrets https://charts.external-secrets.io
+   helm install external-secrets external-secrets/external-secrets \
+     --namespace external-secrets --create-namespace
+   ```
+
+   Configure a `ClusterSecretStore` named `gsm-store` pointing at your project.
+
+7. **Deploy the chart**
+
+   ```bash
+   cd deploy/helm/llmhive
+   helm upgrade --install llmhive . \
+     --namespace llmhive --create-namespace \
+     -f values-prod.yaml \
+     --set image.repository=<REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/llmhive_fastapi \
+     --set image.tag=<IMAGE_TAG> \
+     --set ingress.host=LLMHIVE.AI \
+     --set externalSecret.gsmSecretName="projects/<PROJECT_ID>/secrets/llmhive_database_url" \
+     --set workloadIdentity.ksaName=llmhive-app \
+     --set workloadIdentity.gsaEmail=llmhive-app-gsa@<PROJECT_ID>.iam.gserviceaccount.com
+   ```
+
+8. **Verify the deployment**
+   * `kubectl -n llmhive get pods,svc,ingress,externalsecret`
+   * Ensure the ingress address is published and point DNS for `LLMHIVE.AI` to it.
+   * Run database migrations against Cloud SQL (`alembic upgrade head` with the
+     production `DATABASE_URL`).
+
+## Cloud Run runbook (Terraform)
+
+The Terraform configuration under `deploy/cloudrun/terraform` provisions the
+Cloud Run service, attaches a VPC connector, configures IAM, and maps a custom
+domain.
+
+1. **Prerequisites**
+   * Enable the Cloud Run, Artifact Registry, Secret Manager, Cloud Build,
+     Cloud SQL Admin, and VPC Access APIs.
+   * Build and push the container image as in the GKE workflow.
+   * Create a Serverless VPC connector (for example `llmhive-connector`).
+   * Ensure the Secret Manager secret `llmhive_database_url` exists (see the
+     command in the GKE runbook).
+
+2. **Configure Terraform variables**
+
+   ```bash
+   cd deploy/cloudrun/terraform
+   cp env.example.auto.tfvars env.auto.tfvars
+   # edit env.auto.tfvars with your project values
+   ```
+
+   Required values include the project ID, region, service name, Artifact
+   Registry repository/tag, VPC connector name, custom domain, and the
+   database credentials/private IP that correspond to your Cloud SQL instance.
+   The Terraform module defaults the Secret Manager name to
+   `llmhive_database_url`; adjust the variable if your secret is named
+   differently.
+
+3. **Initialise and apply**
+
+   ```bash
+   terraform init
+   terraform apply
+   ```
+
+   The module creates a dedicated Cloud Run service account with access to
+   Secret Manager and Cloud SQL, deploys the service, attaches the VPC
+   connector, and configures public ingress.
+
+4. **Set up the domain mapping**
+   * Terraform creates a `google_cloud_run_domain_mapping`. After the apply
+     finishes, retrieve the required DNS records via `gcloud run domain-mappings
+     describe` and configure them with your DNS provider.
+   * Wait for the SSL certificate to become active before relying on the
+     endpoint.
+
+5. **Confirm deployment**
+   * `gcloud run services describe <SERVICE> --region <REGION>` should report a
+     healthy status.
+   * `curl -I https://LLMHIVE.AI/healthz` should return a 200 once DNS and TLS
+     propagate.
+
+## Final verification checklist
+
+- [ ] `DATABASE_URL` secret exists in Google Secret Manager and contains a valid
+      connection string.
+- [ ] Alembic migrations have been applied to the target database.
+- [ ] Kubernetes pods or Cloud Run revisions report healthy status and can reach
+      the database via the configured networking.
+- [ ] DNS for `LLMHIVE.AI` points to the GKE ingress IP or Cloud Run domain
+      mapping, and TLS certificates show as active.
+- [ ] Monitoring and logging (Cloud Logging, Cloud Monitoring) show no startup
+      errors or permission denials.
+
+## Troubleshooting tips
+
+| Symptom | Resolution |
+| ------- | ---------- |
+| ExternalSecret stuck in `ERROR` | Verify the Workload Identity binding and that the `gsm-store` `ClusterSecretStore` references the correct project. |
+| Pod fails with database connection errors | Confirm the `app-secrets` secret contains the right connection string and that network peering/VPC access to Cloud SQL is configured. |
+| Cloud Run returns 502/504 | Check Cloud Run logs for traceback information and confirm the VPC connector is in the same region and project as the Cloud SQL instance. |
+| Custom domain not issuing TLS | Ensure DNS records match the domain mapping output and allow time for certificate provisioning. |
+
+This documentation should provide everything necessary to stand up LLMHIVE in
+development or production environments with confidence.

--- a/Programing/alembic.ini
+++ b/Programing/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./llmhive.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/Programing/alembic/env.py
+++ b/Programing/alembic/env.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+from pathlib import Path
+import sys
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from app.config import settings  # noqa: E402
+from app.models import Base  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, compare_type=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def main() -> None:
+    """Entrypoint for running migrations."""
+
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+main()

--- a/Programing/alembic/script.py.mako
+++ b/Programing/alembic/script.py.mako
@@ -1,0 +1,15 @@
+"""Generic Alembic migration template."""
+
+from __future__ import annotations
+
+revision = "${up_revision}"
+down_revision = ${down_revision | repr}
+branch_labels = ${branch_labels | repr}
+depends_on = ${depends_on | repr}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/Programing/alembic/versions/20240101_000001_init_db.py
+++ b/Programing/alembic/versions/20240101_000001_init_db.py
@@ -1,0 +1,26 @@
+"""Initial database schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240101_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("full_name", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("email"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("users")

--- a/Programing/app/__init__.py
+++ b/Programing/app/__init__.py
@@ -1,0 +1,3 @@
+"""Application package for LLMHIVE FastAPI service."""
+
+from .main import app  # noqa: F401

--- a/Programing/app/api/__init__.py
+++ b/Programing/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routers and dependencies for the LLMHIVE application."""

--- a/Programing/app/api/routes.py
+++ b/Programing/app/api/routes.py
@@ -1,0 +1,11 @@
+"""Example API routes."""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["examples"])
+
+
+@router.get("/ping")
+async def ping() -> dict[str, str]:
+    """Simple ping endpoint."""
+    return {"message": "pong"}

--- a/Programing/app/config.py
+++ b/Programing/app/config.py
@@ -1,0 +1,24 @@
+"""Application configuration utilities."""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    api_title: str = "LLMHIVE API"
+    database_url: str = "sqlite:///./llmhive.db"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    return Settings()
+
+
+settings = get_settings()

--- a/Programing/app/database.py
+++ b/Programing/app/database.py
@@ -1,0 +1,27 @@
+"""Database session helpers."""
+
+from __future__ import annotations
+
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .config import settings
+
+DATABASE_URL = settings.database_url
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a database session for dependency injection."""
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/Programing/app/main.py
+++ b/Programing/app/main.py
@@ -1,0 +1,18 @@
+"""Main entrypoint for the LLMHIVE FastAPI application."""
+
+from fastapi import FastAPI
+
+from .api.routes import router
+from .config import settings
+
+app = FastAPI(title=settings.api_title)
+
+
+@app.get("/healthz", tags=["health"])
+def healthcheck() -> dict[str, str]:
+    """Return a basic health status payload."""
+
+    return {"status": "ok"}
+
+
+app.include_router(router, prefix="/api")

--- a/Programing/app/models.py
+++ b/Programing/app/models.py
@@ -1,0 +1,17 @@
+"""SQLAlchemy models for LLMHIVE."""
+
+from sqlalchemy import Column, DateTime, Integer, String, func
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class User(Base):
+    """Example user model."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    full_name = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/Programing/deploy/cloudrun/terraform/env.example.auto.tfvars
+++ b/Programing/deploy/cloudrun/terraform/env.example.auto.tfvars
@@ -1,0 +1,12 @@
+# Example Terraform variables for Cloud Run deployment (copy to env.auto.tfvars and edit)
+project_id           = "llmhive-demo-12345"
+region               = "us-central1"
+service_name         = "llmhive-api"
+image_repository     = "<<AR_REPO>>"
+image_tag            = "<<IMAGE_TAG>>"
+ingress_hostname     = "LLMMHIVE.AI"
+vpc_connector_name   = "llmhive-connector"
+db_user              = "<<DB_USER>>"
+db_pass              = "<<DB_PASS>>"
+db_name              = "<<DB_NAME>>"
+cloudsql_private_ip  = "<<CLOUDSQL_IP>>"

--- a/Programing/deploy/cloudrun/terraform/main.tf
+++ b/Programing/deploy/cloudrun/terraform/main.tf
@@ -1,0 +1,114 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.84"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.84"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.image_repository}/llmhive_fastapi:${var.image_tag}"
+}
+
+resource "google_service_account" "llmhive_runner" {
+  account_id   = "llmhive-runner"
+  display_name = "LLMHIVE Cloud Run runtime service account"
+}
+
+resource "google_project_iam_member" "run_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.llmhive_runner.email}"
+}
+
+resource "google_project_iam_member" "run_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.llmhive_runner.email}"
+}
+
+resource "google_cloud_run_service" "llmhive" {
+  provider = google-beta
+
+  name     = var.service_name
+  location = var.region
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/service-account" = google_service_account.llmhive_runner.email
+    }
+  }
+
+  template {
+    spec {
+      service_account_name = google_service_account.llmhive_runner.email
+
+      containers {
+        image = local.image
+
+        ports {
+          container_port = 8000
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = var.database_secret_name
+              version = var.database_secret_version
+            }
+          }
+        }
+      }
+
+      vpc_access {
+        connector = var.vpc_connector_name
+        egress    = "ALL_TRAFFIC"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "public_invoker" {
+  service  = google_cloud_run_service.llmhive.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_domain_mapping" "custom_domain" {
+  provider = google-beta
+
+  location = var.region
+  name     = var.ingress_hostname
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_service.llmhive.name
+  }
+}

--- a/Programing/deploy/cloudrun/terraform/outputs.tf
+++ b/Programing/deploy/cloudrun/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "cloud_run_url" {
+  value       = google_cloud_run_service.llmhive.status[0].url
+  description = "Deployed Cloud Run service URL"
+}
+
+output "domain_mapping" {
+  value       = google_cloud_run_domain_mapping.custom_domain.domain
+  description = "Custom domain mapped to the service"
+}

--- a/Programing/deploy/cloudrun/terraform/variables.tf
+++ b/Programing/deploy/cloudrun/terraform/variables.tf
@@ -1,0 +1,66 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+}
+
+variable "service_name" {
+  type        = string
+  description = "Cloud Run service name"
+}
+
+variable "image_repository" {
+  type        = string
+  description = "Artifact Registry repository name"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag"
+}
+
+variable "ingress_hostname" {
+  type        = string
+  description = "Custom domain for Cloud Run"
+}
+
+variable "vpc_connector_name" {
+  type        = string
+  description = "Serverless VPC connector name"
+}
+
+variable "db_user" {
+  type        = string
+  description = "Database user for the Cloud SQL instance"
+}
+
+variable "db_pass" {
+  type        = string
+  description = "Database password for the Cloud SQL instance"
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name used by the application"
+}
+
+variable "cloudsql_private_ip" {
+  type        = string
+  description = "Private IP address of the Cloud SQL instance"
+}
+
+variable "database_secret_name" {
+  type        = string
+  description = "Secret Manager secret name containing the DATABASE_URL"
+  default     = "llmhive_database_url"
+}
+
+variable "database_secret_version" {
+  type        = string
+  description = "Secret Manager version to pull"
+  default     = "latest"
+}

--- a/Programing/deploy/helm/llmhive/Chart.yaml
+++ b/Programing/deploy/helm/llmhive/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: llmhive
+version: 0.1.0
+appVersion: "0.1.0"
+description: Helm chart for LLMHIVE FastAPI application

--- a/Programing/deploy/helm/llmhive/templates/_helpers.tpl
+++ b/Programing/deploy/helm/llmhive/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "llmhive.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "llmhive.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "llmhive.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "llmhive.labels" -}}
+app.kubernetes.io/name: {{ include "llmhive.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/Programing/deploy/helm/llmhive/templates/deployment.yaml
+++ b/Programing/deploy/helm/llmhive/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llmhive.fullname" . }}
+  labels:
+    {{- include "llmhive.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "llmhive.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "llmhive.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if .Values.workloadIdentity.ksaName }}
+      serviceAccountName: {{ .Values.workloadIdentity.ksaName }}
+      {{- end }}
+      containers:
+        - name: fastapi
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: DATABASE_URL
+              {{- if .Values.useExternalSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: DATABASE_URL
+              {{- else }}
+              value: ""
+              {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/Programing/deploy/helm/llmhive/templates/external-secret.yaml
+++ b/Programing/deploy/helm/llmhive/templates/external-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.useExternalSecret }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gsm-store
+  target:
+    name: app-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: {{ .Values.externalSecret.gsmSecretName }}
+        version: "latest"
+{{- end }}

--- a/Programing/deploy/helm/llmhive/templates/hpa.yaml
+++ b/Programing/deploy/helm/llmhive/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "llmhive.fullname" . }}
+  labels:
+    {{- include "llmhive.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "llmhive.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/Programing/deploy/helm/llmhive/templates/ingress.yaml
+++ b/Programing/deploy/helm/llmhive/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "llmhive.fullname" . }}
+  labels:
+    {{- include "llmhive.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "llmhive.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ printf "%s-tls" (include "llmhive.fullname" .) }}
+  {{- end }}
+{{- end }}

--- a/Programing/deploy/helm/llmhive/templates/service.yaml
+++ b/Programing/deploy/helm/llmhive/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llmhive.fullname" . }}
+  labels:
+    {{- include "llmhive.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "llmhive.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/Programing/deploy/helm/llmhive/templates/serviceaccount.yaml
+++ b/Programing/deploy/helm/llmhive/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.workloadIdentity.ksaName }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.workloadIdentity.ksaName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.workloadIdentity.gsaEmail }}
+{{- end }}

--- a/Programing/deploy/helm/llmhive/values-prod.yaml
+++ b/Programing/deploy/helm/llmhive/values-prod.yaml
@@ -1,0 +1,27 @@
+# Production-specific Helm values for LLMHIVE on GKE Autopilot
+image:
+  repository: "<REGION>-docker.pkg.dev/llmhive-demo-12345/<<AR_REPO>>/llmhive_fastapi"
+  tag: "<<IMAGE_TAG>>"
+
+ingress:
+  enabled: true
+  host: "LLMMHIVE.AI"
+  tls: true
+
+useExternalSecret: true
+externalSecret:
+  gsmSecretName: "projects/llmhive-demo-12345/secrets/llmhive_database_url"
+
+workloadIdentity:
+  ksaName: "llmhive-app"
+  gsaEmail: "llmhive-app-gsa@llmhive-demo-12345.iam.gserviceaccount.com"
+
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "200m"
+    memory: "256Mi"

--- a/Programing/deploy/helm/llmhive/values.yaml
+++ b/Programing/deploy/helm/llmhive/values.yaml
@@ -1,0 +1,39 @@
+replicaCount: 1
+
+image:
+  repository: llmhive/fastapi
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  tls: false
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+useExternalSecret: false
+externalSecret:
+  gsmSecretName: ""
+
+workloadIdentity:
+  ksaName: ""
+  gsaEmail: ""

--- a/Programing/docker-compose.yml
+++ b/Programing/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql+psycopg2://llmhive:llmhive@db:5432/llmhive
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: llmhive
+      POSTGRES_PASSWORD: llmhive
+      POSTGRES_DB: llmhive
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  db-data:

--- a/Programing/pyproject.toml
+++ b/Programing/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llmhive"
+version = "0.1.0"
+description = "LLMHIVE FastAPI service"
+authors = [{name = "LLMHIVE", email = "support@llmhive.ai"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+keywords = ["fastapi", "llm", "backend"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Framework :: FastAPI"
+]
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.29",
+  "sqlalchemy>=2.0",
+  "alembic>=1.13",
+  "psycopg2-binary>=2.9",
+  "python-dotenv>=1.0",
+  "pydantic-settings>=2.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "httpx",
+  "ruff",
+  "mypy"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.11"
+plugins = []
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- update the Cloud Run Terraform example tfvars to include database credential and Cloud SQL IP placeholders that match the deployment guide
- define the new variables (and default the Secret Manager name) in variables.tf so Terraform accepts the example values
- clarify the README instructions so the runbook references the expanded variable list while still noting the default secret name

## Testing
- python -m compileall Programing/app Programing/alembic

------
https://chatgpt.com/codex/tasks/task_e_68cf094a0788832baa0d643d4c3dd44b