### PR TITLE
Handle orchestration requests without explicit models

### DIFF
--- a/llmhive/tests/test_api.py
+++ b/llmhive/tests/test_api.py
@@ -1,4 +1,5 @@
 """API tests for orchestration endpoint."""
+from llmhive.app.config import settings
 from llmhive.app.schemas import OrchestrationRequest
 
 
@@ -13,3 +14,14 @@ def test_orchestrate_endpoint(client):
     assert data["final_response"]
     assert isinstance(data["critiques"], list)
     assert isinstance(data["improvements"], list)
+
+
+def test_orchestrate_endpoint_uses_default_models(client):
+    payload = {"prompt": "Summarize the benefits of electric vehicles."}
+    response = client.post("/api/v1/orchestration/", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["prompt"] == payload["prompt"]
+    assert len(data["initial_responses"]) == len(settings.default_models)
+    assert sorted(data["models"]) == sorted(settings.default_models)


### PR DESCRIPTION
## Summary
- default the orchestration API to the configured DEFAULT_MODELS list when a request omits models
- add defensive logging and a clearer service-unavailable error when no models are available after normalization
- cover the default-models behaviour with an API test that exercises the implicit fallback path

## Testing
- PYTHONPATH=llmhive/src pytest llmhive/tests -q

------
https://chatgpt.com/codex/tasks/task_e_6900120f2bac832b8627062df1832010