### PR TITLE
Disable Docker cache in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
 # 1. Build the container image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/${_SERVICE_NAME}:${COMMIT_SHA}', '.']
+  args: ['build', '--no-cache', '-t', 'gcr.io/${PROJECT_ID}/${_SERVICE_NAME}:${COMMIT_SHA}', '.']
 
 # 2. Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
## Summary
- add the `--no-cache` flag to the Cloud Build docker build step so new images always contain the latest application code

## Testing
- PYTHONPATH=. pytest app/tests/test_production_hardening.py::test_healthz_endpoint_exists -q

------
https://chatgpt.com/codex/tasks/task_e_69003cd49638832ba520f2de9643b3b3