### PR TITLE
Handle OpenAI quota failures by falling back to stub responses

### DIFF
--- a/app/models/language_model.py
+++ b/app/models/language_model.py
@@ -1,46 +1,78 @@
-"""
-LanguageModel: A synchronous wrapper for OpenAI API calls.
-"""
+"""Synchronous wrapper around the OpenAI Chat Completions API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
 from openai import OpenAI
-from typing import Optional, Dict, Any
+
+from .stub_language_model import StubLanguageModel
+
+logger = logging.getLogger(__name__)
+
 
 class LanguageModel:
+    """Encapsulate OpenAI interactions with graceful fallback behaviour."""
+
     def __init__(self, api_key: str, model: str = "gpt-4o"):
-        """
-        Initialize a synchronous language model client.
-        
-        Args:
-            api_key: OpenAI API key
-            model: Model identifier (default: gpt-4o)
-        """
+        """Initialise the OpenAI client and prepare a stub fallback."""
+
         self.client = OpenAI(api_key=api_key)
         self.model = model
+        # Use a stub model as a safety net when quota or network issues occur.
+        self._fallback = StubLanguageModel(model=f"stub-{model}")
 
     def generate(
-        self, 
-        prompt: str, 
+        self,
+        prompt: str,
         system_prompt: Optional[str] = None,
-        response_format: Optional[Dict[str, Any]] = None
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """
-        Generate a response from the language model.
-        
-        Args:
-            prompt: The user prompt
-            system_prompt: Optional system prompt
-            response_format: Optional response format configuration (e.g., {"type": "json_object"})
-            
-        Returns:
-            The generated text response
-        """
+        """Generate a response, falling back to the stub model when OpenAI fails."""
+
         messages = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
-        
+
         kwargs = {"model": self.model, "messages": messages}
         if response_format:
             kwargs["response_format"] = response_format
-        
-        response = self.client.chat.completions.create(**kwargs)
-        return response.choices[0].message.content or ""
+
+        try:
+            response = self.client.chat.completions.create(**kwargs)
+            return response.choices[0].message.content or ""
+        except Exception as exc:
+            if self._should_use_fallback(exc):
+                logger.warning(
+                    "OpenAI chat completion failed due to quota or rate limits; using stub fallback. Error: %s",
+                    exc,
+                )
+                return self._fallback.generate(
+                    prompt,
+                    system_prompt=system_prompt,
+                    response_format=response_format,
+                )
+
+            logger.exception("OpenAI chat completion failed", exc_info=exc)
+            raise
+
+    def _should_use_fallback(self, exc: Exception) -> bool:
+        """Return True when the exception indicates an OpenAI quota or 429 error."""
+
+        message = str(exc).lower()
+        if (
+            "insufficient_quota" in message
+            or "you exceeded your current quota" in message
+            or "rate limit" in message
+        ):
+            return True
+
+        status_code = getattr(exc, "status_code", None)
+        if status_code == 429:
+            return True
+
+        response = getattr(exc, "response", None)
+        response_status = getattr(response, "status_code", None)
+        return response_status == 429

--- a/app/tests/test_language_model_fallback.py
+++ b/app/tests/test_language_model_fallback.py
@@ -1,0 +1,48 @@
+"""Tests for graceful fallback behaviour in :mod:`app.models.language_model`."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+class _FakeQuotaError(Exception):
+    """Mimic the shape of the OpenAI insufficient quota error."""
+
+    def __init__(self, message: str, status_code: int = 429) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = types.SimpleNamespace(status_code=status_code)
+
+
+def test_language_model_falls_back_to_stub(monkeypatch):
+    from app.models.language_model import LanguageModel
+
+    lm = LanguageModel(api_key="test-key", model="gpt-4o")
+
+    def _raise_quota_error(*args, **kwargs):
+        raise _FakeQuotaError("You exceeded your current quota")
+
+    monkeypatch.setattr(lm.client.chat.completions, "create", _raise_quota_error)
+
+    result = lm.generate("What is the capital of Spain?")
+
+    assert "Madrid" in result
+
+
+def test_language_model_propagates_unhandled_errors(monkeypatch):
+    from app.models.language_model import LanguageModel
+
+    lm = LanguageModel(api_key="test-key", model="gpt-4o")
+
+    class _UnexpectedError(Exception):
+        pass
+
+    def _raise_unexpected_error(*args, **kwargs):
+        raise _UnexpectedError("boom")
+
+    monkeypatch.setattr(lm.client.chat.completions, "create", _raise_unexpected_error)
+
+    with pytest.raises(_UnexpectedError):
+        lm.generate("Say hello")


### PR DESCRIPTION
## Summary
- add a stub-based safety net to the synchronous LanguageModel wrapper so quota and rate-limit errors no longer abort orchestration
- emit diagnostic logging when falling back and reuse stub generation for structured prompts
- add regression tests covering the fallback behaviour and unexpected error propagation

## Testing
- pytest app/tests/test_language_model_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_690043c38e18832bab4e807c0771e20e