### PR TITLE
Add HEAD support to /healthz endpoints

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from app.orchestration.router import (
     router as orchestration_router,
     versioned_router as orchestration_v1_router,
@@ -90,9 +90,15 @@ async def startup_event():
 
 # 4. ADD THE HEALTH CHECK ENDPOINT
 @app.get("/healthz", tags=["Health Check"])
-async def health_check():
+async def health_check() -> dict[str, str]:
     """Health check endpoint for Cloud Run readiness and liveness probes."""
     return {"status": "ok"}
+
+
+@app.head("/healthz", tags=["Health Check"], include_in_schema=False)
+async def health_check_head() -> Response:
+    """Fast HEAD response for Cloud Run health checks that use HEAD requests."""
+    return Response(status_code=200)
 
 
 # 5. INCLUDE THE EXISTING API ROUTER (CRITICAL)

--- a/app/tests/test_production_hardening.py
+++ b/app/tests/test_production_hardening.py
@@ -17,12 +17,25 @@ def test_healthz_endpoint_exists():
     import sys
     sys.path.insert(0, '.')
     from app.app import app as fastapi_app
-    
+
     client = TestClient(fastapi_app)
     response = client.get('/healthz')
-    
+
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_healthz_head_endpoint():
+    """HEAD requests against /healthz should return 200 for Cloud Run probes."""
+    import sys
+    sys.path.insert(0, '.')
+    from app.app import app as fastapi_app
+
+    client = TestClient(fastapi_app)
+    response = client.head('/healthz')
+
+    assert response.status_code == 200
+    assert not response.content  # HEAD responses should have no body
 
 
 def test_structured_json_logging():

--- a/llmhive/src/llmhive/app/main.py
+++ b/llmhive/src/llmhive/app/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api import api_router
@@ -58,13 +58,19 @@ async def root() -> dict[str, str]:
 @app.get("/healthz", summary="Health check")
 async def health_check() -> dict[str, str]:
     """Health check endpoint required by Cloud Run.
-    
+
     Note: This is a root-level health check endpoint (/healthz) separate from
     the API-level health check (/api/v1/healthz). Cloud Run and other
     infrastructure components typically expect health checks at the root level.
     """
     logger.info("Health check endpoint called")
     return {"status": "ok"}
+
+
+@app.head("/healthz", summary="Health check (HEAD)", include_in_schema=False)
+async def health_check_head() -> Response:
+    """Head-only health check variant for infrastructure probes."""
+    return Response(status_code=200)
 
 # Include API routers
 app.include_router(api_router, prefix="/api/v1")

--- a/llmhive/tests/test_health.py
+++ b/llmhive/tests/test_health.py
@@ -6,6 +6,14 @@ def test_root_health_endpoint(client):
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
+
+def test_root_health_head_endpoint(client):
+    """HEAD requests to /healthz should succeed for infrastructure probes."""
+    response = client.head("/healthz")
+    assert response.status_code == 200
+    assert response.content == b""
+
+
 def test_health_endpoint(client):
     response = client.get("/api/v1/healthz")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add explicit HEAD handlers for the /healthz route in both FastAPI entrypoints so infrastructure HEAD probes succeed
- extend production hardening and llmhive health tests to cover HEAD behaviour

## Testing
- pytest app/tests/test_production_hardening.py -q
- PYTHONPATH=llmhive/src pytest llmhive/tests/test_health.py -q

------
https://chatgpt.com/codex/tasks/task_e_69004bcbde88832b894476da16f8ccb8