### PR TITLE
Ensure health endpoints respond across aliases

### DIFF
--- a/app/tests/test_production_hardening.py
+++ b/app/tests/test_production_hardening.py
@@ -38,6 +38,34 @@ def test_healthz_head_endpoint():
     assert not response.content  # HEAD responses should have no body
 
 
+def test_health_aliases():
+    """All supported health endpoint aliases should behave identically."""
+    import sys
+    sys.path.insert(0, '.')
+    from app.app import app as fastapi_app
+
+    client = TestClient(fastapi_app)
+
+    for path in ('/health', '/_ah/health', '/healthz'):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+
+def test_health_alias_head_responses():
+    """HEAD requests against alias endpoints should mirror /healthz behaviour."""
+    import sys
+    sys.path.insert(0, '.')
+    from app.app import app as fastapi_app
+
+    client = TestClient(fastapi_app)
+
+    for path in ('/health', '/_ah/health', '/healthz'):
+        response = client.head(path)
+        assert response.status_code == 200
+        assert response.content == b""
+
+
 def test_structured_json_logging():
     """Test that structured JSON logging is configured correctly."""
     import sys

--- a/llmhive/src/llmhive/app/main.py
+++ b/llmhive/src/llmhive/app/main.py
@@ -55,7 +55,10 @@ async def root() -> dict[str, str]:
         "version": "1.0.0"
     }
 
-@app.get("/healthz", summary="Health check")
+HEALTH_PAYLOAD = {"status": "ok"}
+
+
+@app.get("/healthz", summary="Health check", include_in_schema=False)
 async def health_check() -> dict[str, str]:
     """Health check endpoint required by Cloud Run.
 
@@ -64,12 +67,38 @@ async def health_check() -> dict[str, str]:
     infrastructure components typically expect health checks at the root level.
     """
     logger.info("Health check endpoint called")
-    return {"status": "ok"}
+    return HEALTH_PAYLOAD
 
 
 @app.head("/healthz", summary="Health check (HEAD)", include_in_schema=False)
 async def health_check_head() -> Response:
     """Head-only health check variant for infrastructure probes."""
+    return Response(status_code=200)
+
+
+@app.get("/health", include_in_schema=False)
+async def health_alias() -> dict[str, str]:
+    """Backward compatible alias for legacy health checks."""
+    logger.info("Health alias endpoint called")
+    return HEALTH_PAYLOAD
+
+
+@app.head("/health", include_in_schema=False)
+async def health_alias_head() -> Response:
+    """HEAD alias for /health."""
+    return Response(status_code=200)
+
+
+@app.get("/_ah/health", include_in_schema=False)
+async def app_engine_health_alias() -> dict[str, str]:
+    """Compatibility endpoint for Google load balancer probes."""
+    logger.info("App Engine style health endpoint called")
+    return HEALTH_PAYLOAD
+
+
+@app.head("/_ah/health", include_in_schema=False)
+async def app_engine_health_alias_head() -> Response:
+    """HEAD alias for /_ah/health."""
     return Response(status_code=200)
 
 # Include API routers

--- a/llmhive/tests/conftest.py
+++ b/llmhive/tests/conftest.py
@@ -7,7 +7,16 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("LLMHIVE_FAIL_ON_STUB", "false")  # Allow stub responses in tests
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "src"))
+SRC_ROOT = ROOT / "llmhive" / "src"
+LEGACY_SRC_ROOT = ROOT / "src"
+
+if SRC_ROOT.exists():
+    sys.path.insert(0, str(SRC_ROOT))
+elif LEGACY_SRC_ROOT.exists():
+    # Support historic layouts where code lived directly under /src
+    sys.path.insert(0, str(LEGACY_SRC_ROOT))
+else:
+    raise RuntimeError("Unable to locate application source directory for tests")
 
 import pytest
 from fastapi.testclient import TestClient

--- a/llmhive/tests/test_health.py
+++ b/llmhive/tests/test_health.py
@@ -14,6 +14,14 @@ def test_root_health_head_endpoint(client):
     assert response.content == b""
 
 
+def test_root_health_aliases(client):
+    """Ensure legacy health endpoints continue to function."""
+    for path in ("/health", "/_ah/health"):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+
 def test_health_endpoint(client):
     response = client.get("/api/v1/healthz")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add shared health payload helpers and broaden the health-check middleware to cover `/health` and `/_ah/health`
- expose matching aliases in the `llmhive` FastAPI application and fix the test path bootstrapper
- extend health tests to cover the new alias GET/HEAD probes

## Testing
- PYTHONPATH=. pytest app/tests/test_production_hardening.py -k health -q
- PYTHONPATH=llmhive/src pytest llmhive/tests/test_health.py -q

------
https://chatgpt.com/codex/tasks/task_e_6900630f374c832b8f4fadf3d0074f66