### PR TITLE
Enhance orchestrator with planning, memory, and guardrails

### DIFF
--- a/llmhive/src/llmhive/app/guardrails.py
+++ b/llmhive/src/llmhive/app/guardrails.py
@@ -1,0 +1,47 @@
+"""Lightweight guardrail system for validating generated content."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(slots=True)
+class GuardrailReport:
+    """Result of running guardrail checks against content."""
+
+    passed: bool
+    issues: List[str]
+    sanitized_content: str
+    advisories: List[str]
+
+
+class SafetyValidator:
+    """Applies basic safety and factuality heuristics to model output."""
+
+    def __init__(self, banned_phrases: Iterable[str] | None = None) -> None:
+        self.banned_patterns = [re.compile(re.escape(phrase), re.IGNORECASE) for phrase in (banned_phrases or [])]
+        # Default banned phrases reflect operational policies
+        if not self.banned_patterns:
+            self.banned_patterns = [
+                re.compile(r"\bexecute\s+malware\b", re.IGNORECASE),
+                re.compile(r"\bcredit\s*card\s*number\b", re.IGNORECASE),
+            ]
+
+    def inspect(self, content: str) -> GuardrailReport:
+        issues: List[str] = []
+        sanitized = content
+
+        for pattern in self.banned_patterns:
+            if pattern.search(sanitized):
+                issues.append(f"Removed sensitive fragment matching pattern '{pattern.pattern}'.")
+                sanitized = pattern.sub("[REDACTED]", sanitized)
+
+        advisories: List[str] = []
+        if len(sanitized.strip()) < 5:
+            issues.append("Response is unexpectedly short; potential generation failure.")
+        if "citation" in sanitized.lower() and "http" not in sanitized.lower():
+            advisories.append("Consider providing explicit sources for cited information.")
+
+        passed = not issues
+        return GuardrailReport(passed=passed, issues=issues, sanitized_content=sanitized, advisories=advisories)

--- a/llmhive/src/llmhive/app/memory.py
+++ b/llmhive/src/llmhive/app/memory.py
@@ -1,0 +1,102 @@
+"""Conversation memory management for LLMHive."""
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import Conversation, MemoryEntry
+
+
+@dataclass(slots=True)
+class MemoryContext:
+    """Represents contextual information retrieved from memory."""
+
+    conversation_id: int
+    summary: str
+    recent_messages: List[str]
+
+    def as_prompt_context(self) -> str:
+        recent = "\n".join(self.recent_messages)
+        return f"Previous context summary: {self.summary}\nRecent turns:\n{recent}" if recent else self.summary
+
+
+class MemoryManager:
+    """Handles retrieval and persistence of conversational memory."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def _create_conversation(self, *, user_id: str | None, topic: str | None) -> Conversation:
+        conversation = Conversation(user_id=user_id, topic=topic or "general", summary="")
+        self.session.add(conversation)
+        self.session.flush()
+        return conversation
+
+    def get_or_create_conversation(self, conversation_id: Optional[int], *, user_id: str | None, topic: str | None) -> Conversation:
+        if conversation_id:
+            conversation = self.session.get(Conversation, conversation_id)
+            if conversation:
+                return conversation
+        return self._create_conversation(user_id=user_id, topic=topic)
+
+    def append_entry(
+        self,
+        conversation: Conversation,
+        *,
+        role: str,
+        content: str,
+        metadata: dict | None = None,
+    ) -> MemoryEntry:
+        entry = MemoryEntry(
+            conversation_id=conversation.id,
+            role=role,
+            content=content,
+            payload=metadata or {},
+            created_at=dt.datetime.utcnow(),
+        )
+        self.session.add(entry)
+        return entry
+
+    def fetch_recent_context(self, conversation: Conversation, *, limit: int = 6) -> MemoryContext:
+        stmt = (
+            select(MemoryEntry)
+            .where(MemoryEntry.conversation_id == conversation.id)
+            .order_by(MemoryEntry.created_at.desc())
+            .limit(limit)
+        )
+        rows = list(self.session.scalars(stmt))
+        recent = list(reversed([entry.render_for_prompt() for entry in rows]))
+        summary = conversation.summary or "No long-term summary recorded yet."
+        return MemoryContext(conversation_id=conversation.id, summary=summary, recent_messages=recent)
+
+    def update_summary(self, conversation: Conversation, *, summary: str) -> None:
+        conversation.summary = summary
+        conversation.updated_at = dt.datetime.utcnow()
+        self.session.add(conversation)
+
+    def auto_summarize(self, conversation: Conversation) -> None:
+        stmt = (
+            select(MemoryEntry)
+            .where(MemoryEntry.conversation_id == conversation.id)
+            .order_by(MemoryEntry.created_at.desc())
+            .limit(20)
+        )
+        entries = list(self.session.scalars(stmt))
+        if not entries:
+            conversation.summary = "No prior conversation."  # type: ignore[assignment]
+            return
+        snippets = [entry.content for entry in entries[-5:]]
+        summary = " | ".join(snippet[:120] for snippet in snippets)
+        conversation.summary = summary
+        conversation.updated_at = dt.datetime.utcnow()
+        self.session.add(conversation)
+
+
+def build_context_string(context: MemoryContext | None) -> str | None:
+    if context is None:
+        return None
+    return context.as_prompt_context()

--- a/llmhive/src/llmhive/app/model_registry.py
+++ b/llmhive/src/llmhive/app/model_registry.py
@@ -1,0 +1,204 @@
+"""Model registry and dynamic team selection utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+from .services.base import LLMProvider
+
+
+@dataclass(slots=True)
+class ModelProfile:
+    """Metadata describing a model's strengths and operational characteristics."""
+
+    name: str
+    provider_key: str
+    capabilities: Sequence[str]
+    cost_rating: int
+    latency_rating: int
+    max_context: int
+    preferred_roles: Sequence[str]
+
+    def score_for_capabilities(self, requested: Iterable[str]) -> float:
+        requested_set = set(requested)
+        available = requested_set.intersection(self.capabilities)
+        coverage = len(available) / max(len(requested_set), 1)
+        efficiency = 1.0 / (self.cost_rating + self.latency_rating)
+        return coverage + 0.15 * efficiency
+
+
+class ModelRegistry:
+    """Holds model metadata and provides dynamic selection helpers."""
+
+    def __init__(self, providers: Mapping[str, LLMProvider]):
+        self.providers = providers
+        self._profiles: List[ModelProfile] = self._bootstrap_profiles()
+
+    def _bootstrap_profiles(self) -> List[ModelProfile]:
+        """Return baseline metadata for all supported models."""
+
+        profiles = [
+            ModelProfile(
+                name="gpt-4.1",
+                provider_key="openai",
+                capabilities=("reasoning", "coding", "analysis", "synthesis"),
+                cost_rating=3,
+                latency_rating=3,
+                max_context=128_000,
+                preferred_roles=("draft", "synthesize"),
+            ),
+            ModelProfile(
+                name="gpt-4o",
+                provider_key="openai",
+                capabilities=("reasoning", "multimodal", "editing"),
+                cost_rating=2,
+                latency_rating=2,
+                max_context=96_000,
+                preferred_roles=("draft", "fact_check"),
+            ),
+            ModelProfile(
+                name="gpt-4o-mini",
+                provider_key="openai",
+                capabilities=("reasoning", "fast", "editing"),
+                cost_rating=1,
+                latency_rating=1,
+                max_context=32_000,
+                preferred_roles=("critique", "fact_check"),
+            ),
+            ModelProfile(
+                name="gpt-3.5-turbo",
+                provider_key="openai",
+                capabilities=("fast", "chat"),
+                cost_rating=1,
+                latency_rating=1,
+                max_context=16_000,
+                preferred_roles=("draft",),
+            ),
+            ModelProfile(
+                name="claude-3-opus-20240229",
+                provider_key="anthropic",
+                capabilities=("reasoning", "long_context", "writing"),
+                cost_rating=3,
+                latency_rating=2,
+                max_context=200_000,
+                preferred_roles=("draft", "synthesize"),
+            ),
+            ModelProfile(
+                name="claude-3-sonnet-20240229",
+                provider_key="anthropic",
+                capabilities=("reasoning", "analysis", "retrieval"),
+                cost_rating=2,
+                latency_rating=2,
+                max_context=200_000,
+                preferred_roles=("research", "draft"),
+            ),
+            ModelProfile(
+                name="claude-3-haiku-20240307",
+                provider_key="anthropic",
+                capabilities=("fast", "summarization"),
+                cost_rating=1,
+                latency_rating=1,
+                max_context=200_000,
+                preferred_roles=("draft", "critique"),
+            ),
+            ModelProfile(
+                name="grok-1",
+                provider_key="grok",
+                capabilities=("reasoning", "critical_thinking"),
+                cost_rating=2,
+                latency_rating=2,
+                max_context=32_000,
+                preferred_roles=("critique", "fact_check"),
+            ),
+            ModelProfile(
+                name="gemini-1.5-pro",
+                provider_key="gemini",
+                capabilities=("retrieval", "analysis", "multimodal"),
+                cost_rating=2,
+                latency_rating=2,
+                max_context=100_000,
+                preferred_roles=("research", "draft"),
+            ),
+            ModelProfile(
+                name="gemini-1.5-flash",
+                provider_key="gemini",
+                capabilities=("fast", "summarization"),
+                cost_rating=1,
+                latency_rating=1,
+                max_context=100_000,
+                preferred_roles=("critique", "fact_check"),
+            ),
+            ModelProfile(
+                name="deepseek-chat",
+                provider_key="deepseek",
+                capabilities=("fast", "coding", "analysis"),
+                cost_rating=1,
+                latency_rating=1,
+                max_context=32_000,
+                preferred_roles=("fact_check", "critique"),
+            ),
+            ModelProfile(
+                name="deepseek-reasoner",
+                provider_key="deepseek",
+                capabilities=("reasoning", "analysis", "math"),
+                cost_rating=1,
+                latency_rating=2,
+                max_context=64_000,
+                preferred_roles=("draft", "critique"),
+            ),
+            ModelProfile(
+                name="manus-gpt-ensemble",
+                provider_key="manus",
+                capabilities=("reasoning", "aggregation"),
+                cost_rating=2,
+                latency_rating=2,
+                max_context=64_000,
+                preferred_roles=("synthesize", "draft"),
+            ),
+            ModelProfile(
+                name="stub-v1",
+                provider_key="stub",
+                capabilities=("fallback",),
+                cost_rating=0,
+                latency_rating=0,
+                max_context=8_000,
+                preferred_roles=("draft",),
+            ),
+        ]
+        return profiles
+
+    def available_profiles(self) -> List[ModelProfile]:
+        keys = set(self.providers.keys())
+        return [profile for profile in self._profiles if profile.provider_key in keys]
+
+    def suggest_team(self, required_roles: Sequence[str], required_capabilities: Sequence[Sequence[str]]) -> List[str]:
+        """Return an ordered list of models covering required roles/capabilities."""
+
+        available = self.available_profiles()
+        selected: List[ModelProfile] = []
+
+        for role, capabilities in zip(required_roles, required_capabilities):
+            best: ModelProfile | None = None
+            best_score = -1.0
+            for profile in available:
+                if profile in selected:
+                    continue
+                role_bonus = 0.2 if role in profile.preferred_roles else 0.0
+                score = profile.score_for_capabilities(capabilities) + role_bonus
+                if score > best_score:
+                    best = profile
+                    best_score = score
+            if best:
+                selected.append(best)
+
+        # Ensure at least one model is returned even if no matches found
+        if not selected and available:
+            selected.append(available[0])
+
+        return [profile.name for profile in selected]
+
+    def summarize(self) -> Dict[str, Dict[str, Sequence[str]]]:
+        summary: Dict[str, Dict[str, Sequence[str]]] = {}
+        for profile in self.available_profiles():
+            summary.setdefault(profile.provider_key, {})[profile.name] = profile.capabilities
+        return summary

--- a/llmhive/src/llmhive/app/models.py
+++ b/llmhive/src/llmhive/app/models.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import JSON, DateTime, Integer, Text
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
@@ -24,12 +24,55 @@ class Task(Base):
     critiques: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSON)
     improvements: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSON)
     final_response: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[dt.datetime] = mapped_column(
-        DateTime, default=dt.datetime.utcnow, nullable=False, index=True
-    )
+    conversation_id: Mapped[int | None] = mapped_column(ForeignKey("conversations.id"), nullable=True, index=True)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow, nullable=False, index=True)
     updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime,
         default=dt.datetime.utcnow,
         onupdate=dt.datetime.utcnow,
         nullable=False,
     )
+
+    conversation: Mapped[Optional["Conversation"]] = relationship("Conversation", back_populates="tasks")
+
+
+class Conversation(Base):
+    """Conversation metadata for persistent memory."""
+
+    __tablename__ = "conversations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)
+    topic: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    summary: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow, nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime,
+        default=dt.datetime.utcnow,
+        onupdate=dt.datetime.utcnow,
+        nullable=False,
+    )
+
+    entries: Mapped[List["MemoryEntry"]] = relationship(
+        "MemoryEntry", back_populates="conversation", cascade="all, delete-orphan"
+    )
+    tasks: Mapped[List["Task"]] = relationship("Task", back_populates="conversation")
+
+
+class MemoryEntry(Base):
+    """Individual conversational memory entries."""
+
+    __tablename__ = "memory_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(32), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict | None] = mapped_column("metadata", JSON, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow, nullable=False)
+
+    conversation: Mapped[Conversation] = relationship("Conversation", back_populates="entries")
+
+    def render_for_prompt(self) -> str:
+        prefix = "User" if self.role == "user" else "Assistant"
+        return f"{prefix}: {self.content}"

--- a/llmhive/src/llmhive/app/planner.py
+++ b/llmhive/src/llmhive/app/planner.py
@@ -1,0 +1,154 @@
+"""Heuristic reasoning planner for LLMHive orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, List, Sequence, Set
+
+
+class PlanRole(str, Enum):
+    """Enumerates the high-level roles supported by the orchestrator."""
+
+    DRAFT = "draft"
+    RESEARCH = "research"
+    FACT_CHECK = "fact_check"
+    CRITIQUE = "critique"
+    SYNTHESIZE = "synthesize"
+    RETRIEVAL = "retrieval"
+
+
+@dataclass(slots=True)
+class PlanStep:
+    """Represents a single stage in the reasoning plan."""
+
+    role: PlanRole
+    description: str
+    required_capabilities: Set[str] = field(default_factory=set)
+    candidate_models: Sequence[str] = field(default_factory=list)
+    parallelizable: bool = True
+
+
+@dataclass(slots=True)
+class ReasoningPlan:
+    """Structured reasoning plan produced for a prompt."""
+
+    strategy: str
+    steps: List[PlanStep]
+    confidence: float
+    focus_areas: Sequence[str] = field(default_factory=list)
+    context_summary: str | None = None
+
+    def model_hints(self) -> List[str]:
+        """Return flattened list of model hints gathered from steps."""
+
+        hints: List[str] = []
+        for step in self.steps:
+            hints.extend(step.candidate_models)
+        return hints
+
+
+class ReasoningPlanner:
+    """Derives a hierarchical, role-aware plan for a given prompt."""
+
+    def create_plan(self, prompt: str, *, context: str | None = None) -> ReasoningPlan:
+        lowered = prompt.lower()
+        focus: List[str] = []
+        steps: List[PlanStep] = []
+
+        if any(keyword in lowered for keyword in ("debug", "code", "stack trace", "exception")):
+            focus.append("coding")
+            steps.extend(
+                [
+                    PlanStep(
+                        role=PlanRole.DRAFT,
+                        description="Generate an initial diagnostic or solution proposal for the coding issue.",
+                        required_capabilities={"coding", "analysis"},
+                        candidate_models=["gpt-4.1", "gpt-4o", "deepseek-reasoner"],
+                    ),
+                    PlanStep(
+                        role=PlanRole.FACT_CHECK,
+                        description="Validate code snippets or calculations and ensure reproducibility.",
+                        required_capabilities={"code_execution", "validation"},
+                        candidate_models=["gpt-4o-mini", "deepseek-chat"],
+                    ),
+                ]
+            )
+        elif any(keyword in lowered for keyword in ("research", "analysis", "compare", "impact")):
+            focus.append("research")
+            steps.extend(
+                [
+                    PlanStep(
+                        role=PlanRole.RESEARCH,
+                        description="Gather supporting evidence, statistics, or references relevant to the topic.",
+                        required_capabilities={"retrieval", "analysis"},
+                        candidate_models=["gemini-1.5-pro", "claude-3-sonnet-20240229"],
+                    ),
+                    PlanStep(
+                        role=PlanRole.DRAFT,
+                        description="Compose a comprehensive answer that integrates retrieved context.",
+                        required_capabilities={"reasoning", "long_context"},
+                        candidate_models=["claude-3-opus-20240229", "gpt-4.1"],
+                    ),
+                ]
+            )
+        elif any(keyword in lowered for keyword in ("summarize", "summary", "synthesize")):
+            focus.append("summarization")
+            steps.extend(
+                [
+                    PlanStep(
+                        role=PlanRole.DRAFT,
+                        description="Produce an initial structured summary covering the key points.",
+                        required_capabilities={"summarization"},
+                        candidate_models=["claude-3-haiku-20240307", "gpt-4o-mini"],
+                    ),
+                    PlanStep(
+                        role=PlanRole.CRITIQUE,
+                        description="Critique the summary for missing context or unclear structure.",
+                        required_capabilities={"critical_thinking"},
+                        candidate_models=["grok-1", "deepseek-chat"],
+                    ),
+                ]
+            )
+        else:
+            focus.append("general_reasoning")
+            steps.append(
+                PlanStep(
+                    role=PlanRole.DRAFT,
+                    description="Generate a high-quality first draft response.",
+                    required_capabilities={"reasoning"},
+                    candidate_models=["gpt-4o", "claude-3-sonnet-20240229"],
+                )
+            )
+
+        # Always include cross-critique and synthesis phases to align with hive workflow
+        steps.append(
+            PlanStep(
+                role=PlanRole.CRITIQUE,
+                description="Cross-review answers to surface disagreements or factual gaps.",
+                required_capabilities={"critical_thinking", "fact_checking"},
+                candidate_models=["grok-1", "deepseek-reasoner", "gpt-4o-mini"],
+            )
+        )
+        steps.append(
+            PlanStep(
+                role=PlanRole.SYNTHESIZE,
+                description="Merge improved answers into a unified, polished response with citations or caveats as needed.",
+                required_capabilities={"synthesis", "editing"},
+                candidate_models=["gpt-4.1", "claude-3-opus-20240229"],
+                parallelizable=False,
+            )
+        )
+
+        strategy = "hierarchical_plan_with_iterative_refinement"
+        confidence = 0.75 if len(focus) > 1 else 0.65
+
+        if context:
+            focus.append("contextual_memory")
+
+        return ReasoningPlan(
+            strategy=strategy,
+            steps=steps,
+            confidence=confidence,
+            focus_areas=focus,
+            context_summary=context,
+        )

--- a/llmhive/src/llmhive/app/schemas.py
+++ b/llmhive/src/llmhive/app/schemas.py
@@ -36,6 +36,10 @@ class OrchestrationRequest(BaseModel):
     models: Optional[List[str]] = Field(
         default=None, description="Optional explicit list of model identifiers"
     )
+    user_id: Optional[str] = Field(default=None, description="Identifier for the requesting user")
+    conversation_id: Optional[int] = Field(default=None, description="Existing conversation identifier")
+    topic: Optional[str] = Field(default=None, description="Optional topic hint for memory organization")
+    enable_memory: bool = Field(default=True, description="Enable conversational memory retrieval and storage")
 
 
 class OrchestrationResponse(BaseModel):
@@ -47,6 +51,11 @@ class OrchestrationResponse(BaseModel):
     critiques: List[Critique]
     improvements: List[Improvement]
     final_response: str
+    conversation_id: Optional[int]
+    consensus_notes: List[str]
+    plan: Dict[str, Any]
+    guardrails: Optional[Dict[str, Any]]
+    context: Optional[str]
 
 
 class TaskRecord(BaseModel):
@@ -56,6 +65,7 @@ class TaskRecord(BaseModel):
     prompt: str
     models: List[str] = Field(alias="model_names")
     final_response: str
+    conversation_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 

--- a/llmhive/src/llmhive/app/services/anthropic_provider.py
+++ b/llmhive/src/llmhive/app/services/anthropic_provider.py
@@ -51,6 +51,14 @@ class AnthropicProvider(LLMProvider):
             api_key=key,
             timeout=timeout or getattr(settings, "anthropic_timeout_seconds", 45.0)
         )
+        self._models = [
+            "claude-3-opus-20240229",
+            "claude-3-sonnet-20240229",
+            "claude-3-haiku-20240307",
+        ]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _chat(self, messages: list[dict[str, str]], *, model: str, system: str | None = None) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/base.py
+++ b/llmhive/src/llmhive/app/services/base.py
@@ -41,3 +41,7 @@ class LLMProvider(Protocol):
         model: str,
     ) -> LLMResult:
         """Return an improved answer given critiques."""
+
+    def list_models(self) -> list[str]:
+        """Return the models exposed by this provider (best-effort)."""
+        raise NotImplementedError

--- a/llmhive/src/llmhive/app/services/deepseek_provider.py
+++ b/llmhive/src/llmhive/app/services/deepseek_provider.py
@@ -49,6 +49,10 @@ class DeepSeekProvider(LLMProvider):
             base_url="https://api.deepseek.com/v1",
             timeout=timeout or getattr(settings, "deepseek_timeout_seconds", 45.0)
         )
+        self._models = ["deepseek-chat", "deepseek-reasoner"]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _chat(self, messages: List[Dict[str, str]], *, model: str) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/gemini_provider.py
+++ b/llmhive/src/llmhive/app/services/gemini_provider.py
@@ -48,6 +48,14 @@ class GeminiProvider(LLMProvider):
         genai.configure(api_key=key)
         self.genai = genai
         self.timeout = timeout or getattr(settings, "gemini_timeout_seconds", 45.0)
+        self._models = [
+            "gemini-1.5-pro",
+            "gemini-1.5-flash",
+            "gemini-1.0-pro-vision",
+        ]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _generate(self, prompt: str, *, model: str, system_instruction: str | None = None) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/grok_provider.py
+++ b/llmhive/src/llmhive/app/services/grok_provider.py
@@ -50,6 +50,10 @@ class GrokProvider(LLMProvider):
             base_url="https://api.x.ai/v1",
             timeout=timeout or getattr(settings, "grok_timeout_seconds", 45.0)
         )
+        self._models = ["grok-1", "grok-beta"]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _chat(self, messages: List[Dict[str, str]], *, model: str) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/manus_provider.py
+++ b/llmhive/src/llmhive/app/services/manus_provider.py
@@ -52,6 +52,10 @@ class ManusProvider(LLMProvider):
             base_url=url,
             timeout=timeout or getattr(settings, "manus_timeout_seconds", 45.0)
         )
+        self._models = ["manus-gpt-ensemble", "manus-claude-bridge", "manus-cascade-lite"]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _chat(self, messages: List[Dict[str, str]], *, model: str) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/openai_provider.py
+++ b/llmhive/src/llmhive/app/services/openai_provider.py
@@ -49,6 +49,17 @@ class OpenAIProvider(LLMProvider):
         if not key:
             raise ProviderNotConfiguredError("OpenAI API key is missing.")
         self.client = AsyncOpenAI(api_key=key, timeout=timeout or settings.openai_timeout_seconds)
+        self._models = [
+            "gpt-4.1",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1-mini",
+            "gpt-3.5-turbo",
+            "gpt-4o-audio-preview",
+        ]
+
+    def list_models(self) -> list[str]:
+        return list(self._models)
 
     async def _chat(self, messages: List[Dict[str, str]], *, model: str) -> LLMResult:
         try:

--- a/llmhive/src/llmhive/app/services/stub_provider.py
+++ b/llmhive/src/llmhive/app/services/stub_provider.py
@@ -16,6 +16,10 @@ class StubProvider(LLMProvider):
 
     def __init__(self, seed: int | None = None) -> None:
         self.random = random.Random(seed)
+        self._models: List[str] = ["stub-v1", "stub-researcher", "stub-critic"]
+
+    def list_models(self) -> List[str]:
+        return list(self._models)
 
     async def _sleep(self) -> None:
         await asyncio.sleep(self.random.uniform(0.01, 0.05))


### PR DESCRIPTION
## Summary
- add dynamic reasoning planner, model registry, and guardrail checks to the orchestrator
- introduce persistent conversation memory with new database tables and API wiring
- expose richer orchestration metadata and provider listings, including provider model catalogs

## Testing
- `pytest` *(fails: Programing/tests require unavailable `app` package)*

------
https://chatgpt.com/codex/tasks/task_e_69007015249c832bae1cabc04c05b4ce