### PR TITLE
Enhance orchestrator planning pipeline with richer agent telemetry

### DIFF
--- a/llmhive/src/llmhive/app/api/orchestration.py
+++ b/llmhive/src/llmhive/app/api/orchestration.py
@@ -235,6 +235,12 @@ async def orchestrate(
         except Exception as exc:
             logger.exception("Failed to update memory entries: %s", exc)
 
+    step_outputs_payload = {
+        role: [ModelAnswer(model=result.model, content=result.content) for result in results]
+        for role, results in artifacts.step_outputs.items()
+    }
+    evaluation_text = artifacts.evaluation.content if artifacts.evaluation else None
+
     return OrchestrationResponse(
         prompt=payload.prompt,
         models=[ans.model for ans in artifacts.initial_responses],
@@ -247,4 +253,7 @@ async def orchestrate(
         plan=plan_dict,
         guardrails=guardrail_payload,
         context=context_string,
+        step_outputs=step_outputs_payload,
+        supporting_notes=artifacts.supporting_notes,
+        evaluation=evaluation_text,
     )

--- a/llmhive/src/llmhive/app/schemas.py
+++ b/llmhive/src/llmhive/app/schemas.py
@@ -56,6 +56,18 @@ class OrchestrationResponse(BaseModel):
     plan: Dict[str, Any]
     guardrails: Optional[Dict[str, Any]]
     context: Optional[str]
+    step_outputs: Dict[str, List[ModelAnswer]] = Field(
+        default_factory=dict,
+        description="Outputs produced during each plan step.",
+    )
+    supporting_notes: List[str] = Field(
+        default_factory=list,
+        description="Aggregated research and fact-check snippets shared across agents.",
+    )
+    evaluation: Optional[str] = Field(
+        default=None,
+        description="Quality review summary of the final response.",
+    )
 
 
 class TaskRecord(BaseModel):


### PR DESCRIPTION
## Summary
- execute reasoning plans step-by-step in the orchestrator, capture supporting evidence, and add an evaluation stage for the final answer
- expose detailed step outputs, research notes, and evaluation feedback through the orchestration API response
- extend the response schema to carry the additional orchestration metadata for downstream consumers

## Testing
- pytest llmhive/tests/test_orchestrator.py llmhive/tests/test_api.py llmhive/tests/test_critique_authors.py


------
https://chatgpt.com/codex/tasks/task_e_6900750b130c832bb670871e13cd0284