### PR TITLE
Enhance orchestrator quality scoring and synthesis context

### DIFF
--- a/llmhive/src/llmhive/app/config.py
+++ b/llmhive/src/llmhive/app/config.py
@@ -44,7 +44,10 @@ class Settings(BaseSettings):
     manus_api_key: str | None = Field(default=None, alias="MANUS_API_KEY")
     manus_base_url: str | None = Field(default=None, alias="MANUS_BASE_URL")
     manus_timeout_seconds: float = Field(default=45.0, alias="MANUS_TIMEOUT_SECONDS")
-    
+
+    # Orchestrator heuristics
+    minimum_quality_score: float = Field(default=0.3, alias="MINIMUM_QUALITY_SCORE")
+
     default_models: List[str] = Field(
         default_factory=lambda: ["gpt-4o-mini", "gpt-3.5-turbo"], alias="DEFAULT_MODELS"
     )


### PR DESCRIPTION
## Summary
- add response quality assessments to orchestrator runs and propagate them through critique, improvement, synthesis, and evaluation prompts
- expose a configurable MINIMUM_QUALITY_SCORE setting to tune DeepConf-inspired filtering thresholds
- surface quality-derived consensus signals so downstream stages can prioritize stronger contributions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6900fcb78e34832ba53d02abb0ca2959