### PR TITLE
Add configurable CORS support for orchestration API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,12 @@ class Settings(BaseSettings):
     CRITIQUE_MODEL: str = "gpt-4"
     SYNTHESIS_MODEL: str = "gpt-4-turbo"
     
+    # Cross-origin resource sharing (CORS)
+    # Comma-separated list of allowed origins for the FastAPI service.
+    # Defaults to "*" for local development convenience. In production,
+    # set this to your deployed front-end domain(s).
+    CORS_ALLOW_ORIGINS: str = "*"
+
     # Application metadata
     LOG_LEVEL: str = "INFO"
     APP_NAME: str = "LLMHive"


### PR DESCRIPTION
## Summary
- add a configurable CORS allow-origins setting to the orchestrator service
- register FastAPI CORS middleware using the configured origins and log the active policy

## Testing
- pytest app/tests -q

------
https://chatgpt.com/codex/tasks/task_e_69014f37aa14832b8332d5a1d7183b39