### PR TITLE
Fix orchestration proxy default port

### DIFF
--- a/ui/.env.local.example
+++ b/ui/.env.local.example
@@ -10,5 +10,5 @@ GITHUB_ID=your-github-oauth-app-client-id
 GITHUB_SECRET=your-github-oauth-app-client-secret
 
 # Orchestrator API (used by server-side proxy route)
-# Defaults to http://127.0.0.1:8000 for local development
-ORCHESTRATOR_API_BASE_URL=http://127.0.0.1:8000
+# Defaults to http://127.0.0.1:8080 for local development
+ORCHESTRATOR_API_BASE_URL=http://127.0.0.1:8080

--- a/ui/README.md
+++ b/ui/README.md
@@ -45,8 +45,8 @@ AUTH_SECRET=<your-generated-secret>
 GITHUB_ID=<your-github-client-id>
 GITHUB_SECRET=<your-github-client-secret>
 # URL where the Python orchestrator API is running
-# For local development the default FastAPI server listens on http://127.0.0.1:8000
-ORCHESTRATOR_API_BASE_URL=http://127.0.0.1:8000
+# For local development the default FastAPI server listens on http://127.0.0.1:8080
+ORCHESTRATOR_API_BASE_URL=http://127.0.0.1:8080
 ```
 
 ### Installation

--- a/ui/app/api/v1/orchestration/route.ts
+++ b/ui/app/api/v1/orchestration/route.ts
@@ -6,7 +6,7 @@ const PUBLIC_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 const CONFIGURED_BASE =
   process.env.ORCHESTRATOR_API_BASE_URL ?? (PUBLIC_BASE || undefined);
 
-const DEFAULT_LOCAL_BASE = "http://127.0.0.1:8000";
+const DEFAULT_LOCAL_BASE = "http://127.0.0.1:8080";
 const baseToUse = (CONFIGURED_BASE ?? DEFAULT_LOCAL_BASE).replace(/\/$/, "");
 const upstreamUrl = `${baseToUse}/api/v1/orchestration`;
 


### PR DESCRIPTION
## Summary
- update the Next.js orchestration proxy to default to the FastAPI service on port 8080
- adjust local environment documentation to reference the correct 8080 backend port

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69015a503364832b8abbd4fb0f40ac45