### PR TITLE
Add helper script to launch backend with correct PYTHONPATH

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -74,12 +74,19 @@ Safety and quality assurance:
 ### Running the Application
 
 ```bash
+# Recommended: use the helper script from the repo root
+./scripts/run_backend.sh
+
 # Using uvicorn directly
-uvicorn app.main:app --reload
+python3 -m uvicorn app.app:app --host 0.0.0.0 --port 8080
 
 # Or with the application file at root
 python app.py
 ```
+
+> **Tip:** `scripts/run_backend.sh` automatically activates `.venv` (if present),
+> exports `PYTHONPATH` so the `app` package can be imported, and finally launches
+> Uvicorn. This removes the need to manage those steps manually on macOS.
 
 ### API Endpoints
 

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# If no virtual environment is active, try to use the local .venv
+if [ -z "${VIRTUAL_ENV:-}" ]; then
+  if [ -x "${PROJECT_ROOT}/.venv/bin/activate" ]; then
+    echo "Activating virtual environment at ${PROJECT_ROOT}/.venv" >&2
+    # shellcheck disable=SC1091
+    source "${PROJECT_ROOT}/.venv/bin/activate"
+  else
+    echo "Warning: .venv not found. Using system python3." >&2
+  fi
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 is required to start the backend." >&2
+  exit 1
+fi
+
+export PYTHONPATH="${PROJECT_ROOT}:${PYTHONPATH:-}"
+
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8080}"
+APP_MODULE="app.app:app"
+
+exec python3 -m uvicorn "${APP_MODULE}" --host "${HOST}" --port "${PORT}"


### PR DESCRIPTION
## Summary
- add a scripts/run_backend.sh helper that ensures the project root is on PYTHONPATH before starting uvicorn
- automatically activate the local virtual environment when available
- update the app README with instructions for using the helper script or running uvicorn directly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69015cfd0a14832b9aa846ff30627fe3