### PR TITLE
Refine deterministic agent workflow utilities

### DIFF
--- a/Programing/tests/conftest.py
+++ b/Programing/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for Programing unit tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/app/model_selector.py
+++ b/app/model_selector.py
@@ -1,0 +1,49 @@
+"""Utilities for profiling and selecting language models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Represents a deployable language model option."""
+
+    name: str
+    strengths: Sequence[str]
+    cost: float
+    latency: float
+
+
+class ModelSelector:
+    """Keeps track of available models and performs simple matching."""
+
+    def __init__(self) -> None:
+        self.models: List[ModelProfile] = []
+
+    def add_model(self, profile: ModelProfile) -> None:
+        """Register a new model profile."""
+
+        if not isinstance(profile, ModelProfile):  # pragma: no cover - defensive branch
+            raise TypeError("profile must be a ModelProfile instance")
+        self.models.append(profile)
+
+    def select_models(self, task_requirements: Iterable[str]) -> List[ModelProfile]:
+        """Return models that advertise support for at least one requirement."""
+
+        requirements = {req.lower() for req in task_requirements if req}
+        if not requirements:
+            return []
+
+        scored_matches: List[tuple[int, ModelProfile]] = []
+        for model in self.models:
+            strengths = {strength.lower() for strength in model.strengths}
+            overlap = strengths & requirements
+            if overlap:
+                scored_matches.append((len(overlap), model))
+
+        scored_matches.sort(
+            key=lambda item: (-item[0], item[1].cost, item[1].latency, item[1].name)
+        )
+        return [model for _, model in scored_matches]

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,0 +1,54 @@
+"""A minimal orchestrator that coordinates the simple agent roles."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .roles import Critic, LeadResponder, Researcher, Synthesizer
+from .scratchpad import Scratchpad
+from .validator import Validator
+
+
+class Orchestrator:
+    """Runs a deterministic multi-agent workflow used in tests."""
+
+    def __init__(self) -> None:
+        self.scratchpad = Scratchpad()
+        self.validator = Validator()
+
+    def orchestrate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        lead = LeadResponder("LeadResponder")
+        draft_payload = lead.execute(input_data)
+        draft_text = draft_payload.get("draft", "")
+        self.scratchpad.add_entry("draft", draft_text)
+
+        researcher = Researcher("Researcher")
+        research_payload = researcher.execute(input_data)
+        research_notes = research_payload.get("research", "")
+        self.scratchpad.add_entry("research", research_notes)
+
+        critic = Critic("Critic")
+        critique_payload = critic.execute({
+            "draft": draft_text,
+            "research": research_notes,
+        })
+        critique_notes = critique_payload.get("critique", "")
+        self.scratchpad.add_entry("critique", critique_notes)
+
+        synthesizer = Synthesizer("Synthesizer")
+        final_payload = synthesizer.execute(self.scratchpad.snapshot())
+        final_text = final_payload.get("final_response", "")
+
+        result = {
+            "draft": draft_text,
+            "research": research_notes,
+            "critique": critique_notes,
+            "final_response": final_text,
+            "format": "text",
+        }
+
+        if not self.validator.validate_output(result):
+            return {"error": "Validation failed"}
+
+        self.scratchpad.add_entry("final_response", final_text)
+        return result

--- a/app/roles.py
+++ b/app/roles.py
@@ -1,0 +1,59 @@
+"""Definitions of lightweight agent roles used by the orchestrator tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class AgentRole:
+    """Base class representing a simple agent role."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - interface contract
+        """Execute the role's task."""
+
+        raise NotImplementedError("Subclasses must implement execute().")
+
+
+class LeadResponder(AgentRole):
+    """Agent responsible for producing an initial draft response."""
+
+    def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        topic = input_data.get("input")
+        return {
+            "draft": "Generated main draft response",
+            "context": topic,
+        }
+
+
+class Researcher(AgentRole):
+    """Agent responsible for fetching supporting information."""
+
+    def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        topic = input_data.get("input")
+        return {
+            "research": "Fetched supporting information",
+            "context": topic,
+        }
+
+
+class Critic(AgentRole):
+    """Agent responsible for evaluating draft content."""
+
+    def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "critique": "Critique of the draft provided",
+            "notes": input_data.get("draft"),
+        }
+
+
+class Synthesizer(AgentRole):
+    """Agent responsible for combining intermediate results."""
+
+    def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "final_response": "Synthesized final response",
+            "sources": list(input_data.keys()),
+        }

--- a/app/scratchpad.py
+++ b/app/scratchpad.py
@@ -1,0 +1,26 @@
+"""Simple shared scratchpad for orchestrator coordination tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class Scratchpad:
+    """Stores intermediate agent results in a dictionary."""
+
+    def __init__(self) -> None:
+        self._context: Dict[str, Any] = {}
+
+    def add_entry(self, key: str, value: Any) -> None:
+        self._context[key] = value
+
+    def get_entry(self, key: str) -> Any:
+        return self._context.get(key)
+
+    def clear(self) -> None:
+        self._context.clear()
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a shallow copy of the stored context."""
+
+        return dict(self._context)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Ensure the project root is importable when running the app test suite."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/app/validator.py
+++ b/app/validator.py
@@ -1,0 +1,28 @@
+"""Validation helpers used by the orchestrator tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class Validator:
+    """Performs lightweight safety and formatting checks."""
+
+    @staticmethod
+    def validate_output(output: Dict[str, Any]) -> bool:
+        if not isinstance(output, dict):  # pragma: no cover - defensive branch
+            return False
+
+        if "disallowed_content" in output:
+            return False
+
+        final_response = output.get("final_response")
+        if final_response is None:
+            return True
+
+        return isinstance(final_response, str) and bool(final_response.strip())
+
+    @staticmethod
+    def format_check(output: Dict[str, Any]) -> bool:
+        format_value = output.get("format")
+        return isinstance(format_value, str) and bool(format_value)


### PR DESCRIPTION
## Summary
- refine the app modules for model selection, orchestration, roles, scratchpad, and validation to capture richer context while remaining deterministic for the programming tests
- ensure both the programming and main app test suites can import the project package by adjusting their pytest configuration

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_69019704f664832b8cb51c24d19575ff