### PR TITLE
Improve stub responses for Spanish city queries

### DIFF
--- a/app/models/stub_provider.py
+++ b/app/models/stub_provider.py
@@ -32,6 +32,22 @@ class StubProvider(LLMProvider):
         
         if "capital" in user_msg_lower and "spain" in user_msg_lower:
             return "The capital of Spain is Madrid."
+
+        if ("list" in user_msg_lower or "largest" in user_msg_lower or "biggest" in user_msg_lower) \
+            and "spain" in user_msg_lower and ("city" in user_msg_lower or "cities" in user_msg_lower):
+            return (
+                "Here are Spain's 10 largest cities by population:\n"
+                "1. Madrid\n"
+                "2. Barcelona\n"
+                "3. Valencia\n"
+                "4. Seville (Sevilla)\n"
+                "5. Zaragoza\n"
+                "6. Málaga\n"
+                "7. Murcia\n"
+                "8. Palma de Mallorca\n"
+                "9. Las Palmas de Gran Canaria\n"
+                "10. Bilbao"
+            )
         
         # Default response
         return f"This is a stub response from {model}. The system is working correctly, but no real LLM API keys are configured. Please add API keys to get actual AI-powered responses.\n\nYour question: {user_msg[:100]}..."

--- a/llmhive/src/llmhive/app/services/stub_provider.py
+++ b/llmhive/src/llmhive/app/services/stub_provider.py
@@ -104,6 +104,18 @@ class StubProvider(LLMProvider):
 3. Shanghai, China
 4. São Paulo, Brazil
 5. Mexico City, Mexico"""
+            elif "spain" in prompt_lower and ("city" in prompt_lower or "cities" in prompt_lower):
+                return """Here are Spain's 10 largest cities by population:
+1. Madrid
+2. Barcelona
+3. Valencia
+4. Seville (Sevilla)
+5. Zaragoza
+6. Málaga
+7. Murcia
+8. Palma de Mallorca
+9. Las Palmas de Gran Canaria
+10. Bilbao"""
             elif ("usa" in prompt_lower or "united states" in prompt_lower or "american" in prompt_lower or " us " in prompt_lower or prompt_lower.startswith("us ") or prompt_lower.endswith(" us")) and ("city" in prompt_lower or "cities" in prompt_lower):
                 return """Here are the 5 largest cities in the United States by population:
 1. New York City, New York

--- a/llmhive/tests/test_list_cities_issue.py
+++ b/llmhive/tests/test_list_cities_issue.py
@@ -39,6 +39,7 @@ def test_various_list_questions(client):
         ("List the world's 5 largest cities", ["Tokyo", "Delhi", "Shanghai"]),
         ("What are the 5 largest cities in the United States?", ["New York", "Los Angeles", "Chicago"]),
         ("List the largest US cities", ["New York", "Los Angeles", "Chicago"]),
+        ("List the 10 biggest cities in Spain", ["Madrid", "Barcelona", "Valencia"]),
     ]
     
     for prompt, expected_keywords in test_cases:


### PR DESCRIPTION
## Summary
- add deterministic stub answers for prompts requesting the largest cities in Spain
- cover the new scenario with an integration test that ensures real-looking content is returned

## Testing
- `pytest tests/test_list_cities_issue.py`


------
https://chatgpt.com/codex/tasks/task_e_6901a23bce38832b9f8f2e304526f8c5