### PR TITLE
Normalize model aliases before orchestration

### DIFF
--- a/llmhive/tests/test_api.py
+++ b/llmhive/tests/test_api.py
@@ -48,3 +48,20 @@ def test_orchestrate_endpoint_rejects_missing_models(client):
 
     assert response.status_code == 400
     assert "No valid model names" in response.json()["detail"]
+
+
+def test_orchestrate_endpoint_remaps_model_aliases(client):
+    payload = {
+        "prompt": "List notable OSS LLM orchestrators.",
+        "models": ["gpt-4-turbo", "claude-3-opus"],
+    }
+
+    response = client.post("/api/v1/orchestration/", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    returned_models = set(data["models"])
+
+    assert "gpt-4-turbo" not in returned_models
+    assert "claude-3-opus" not in returned_models
+    assert {"gpt-4o", "claude-3-opus-20240229"}.issubset(returned_models)

--- a/llmhive/tests/test_capital_question.py
+++ b/llmhive/tests/test_capital_question.py
@@ -1,5 +1,5 @@
 """Test for the specific capital question scenario from the bug report."""
-import pytest
+from llmhive.app.api.orchestration import MODEL_ALIAS_MAP
 from llmhive.app.schemas import OrchestrationRequest
 
 
@@ -16,9 +16,10 @@ def test_capital_of_spain_question(client):
     
     # Verify the response structure
     assert data["prompt"] == payload.prompt
-    assert data["models"] == ["gpt-4"]
+    expected_model = MODEL_ALIAS_MAP.get("gpt-4", "gpt-4")
+    assert data["models"] == [expected_model]
     assert len(data["initial_responses"]) == 1
-    assert data["initial_responses"][0]["model"] == "gpt-4"
+    assert data["initial_responses"][0]["model"] == expected_model
     
     # Verify the content contains the actual answer
     initial_content = data["initial_responses"][0]["content"]

--- a/ui/app/components/PromptForm.tsx
+++ b/ui/app/components/PromptForm.tsx
@@ -25,22 +25,22 @@ type StrategyOption = {
 
 const MODEL_OPTIONS: Option[] = [
   {
-    value: "gpt-4-turbo",
-    label: "GPT-4 Turbo (OpenAI)",
+    value: "gpt-4o",
+    label: "GPT-4o (OpenAI)",
     description: "Elite reasoning speed, great for complex coding and synthesis.",
   },
   {
-    value: "gpt-4",
-    label: "GPT-4 Legacy (OpenAI)",
+    value: "gpt-4.1",
+    label: "GPT-4.1 (OpenAI)",
     description: "Time-tested depth for analysis-heavy or critical reasoning work.",
   },
   {
-    value: "claude-3-opus",
+    value: "claude-3-opus-20240229",
     label: "Claude 3 Opus (Anthropic)",
     description: "Expansive context window and eloquent long-form writing talent.",
   },
   {
-    value: "claude-3-sonnet",
+    value: "claude-3-sonnet-20240229",
     label: "Claude 3 Sonnet (Anthropic)",
     description: "Responsive collaborator tuned for narrative polish and UX copy.",
   },


### PR DESCRIPTION
## Summary
- remap friendly model aliases in the orchestration API so providers receive canonical identifiers
- update the cockpit model picker to use provider-recognized IDs by default
- extend API regression tests to cover alias handling and expect canonical model names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901a756fec8832b98ac852b76ef0423