### PR TITLE
Fix stub-only orchestration failure

### DIFF
--- a/llmhive/src/llmhive/app/model_registry.py
+++ b/llmhive/src/llmhive/app/model_registry.py
@@ -23,7 +23,10 @@ class ModelProfile:
         requested_set = set(requested)
         available = requested_set.intersection(self.capabilities)
         coverage = len(available) / max(len(requested_set), 1)
-        efficiency = 1.0 / (self.cost_rating + self.latency_rating)
+        # Guard against zero cost/latency values which we use for stub providers.
+        # Treat a zero total as "best possible" efficiency instead of raising.
+        denominator = self.cost_rating + self.latency_rating
+        efficiency = 1.0 / denominator if denominator else 1.0
         return coverage + 0.15 * efficiency
 
 

--- a/llmhive/tests/test_orchestrator.py
+++ b/llmhive/tests/test_orchestrator.py
@@ -17,3 +17,15 @@ async def test_orchestrator_generates_all_stages() -> None:
     for result in artifacts.initial_responses:
         # Stub provider returns informative responses
         assert len(result.content) > 0
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_infers_models_when_only_stub_available() -> None:
+    orchestrator = Orchestrator(providers={"stub": StubProvider(seed=7)})
+    artifacts = await orchestrator.orchestrate("Summarize the role of pollinators in ecosystems.")
+
+    assert artifacts.initial_responses, "Expected at least one draft response"
+    returned_models = {result.model for result in artifacts.initial_responses}
+    # The orchestrator should fall back to the stub model when no real providers exist.
+    assert "stub-v1" in returned_models
+    assert artifacts.final_response.content


### PR DESCRIPTION
## Summary
- prevent division by zero when scoring models with zero cost/latency so stub providers can be selected safely
- add a regression test verifying the orchestrator infers stub models when only the stub provider is available

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_6901ac70d554832b9f88620280c7beab