### PR TITLE
Fix stub-only detection when upstream providers fail

### DIFF
--- a/llmhive/src/llmhive/app/api/orchestration.py
+++ b/llmhive/src/llmhive/app/api/orchestration.py
@@ -211,10 +211,11 @@ async def orchestrate(
     # Only fails if non-stub providers exist (otherwise stub provider is the expected fallback).
     fail_on_stub = os.getenv("LLMHIVE_FAIL_ON_STUB", "true").lower() not in ("0", "false", "no")
     try:
-        all_stub = all(
+        initial_responses = artifacts.initial_responses
+        all_stub = bool(initial_responses) and all(
             isinstance(r.content, str)
             and r.content.startswith(f"[{r.model}] Response to:")
-            for r in artifacts.initial_responses
+            for r in initial_responses
         )
     except Exception:
         all_stub = False

--- a/llmhive/tests/test_orchestrator_stub_fallback.py
+++ b/llmhive/tests/test_orchestrator_stub_fallback.py
@@ -1,0 +1,61 @@
+"""Tests for synthesis-stage fallback to the stub provider."""
+
+from __future__ import annotations
+
+import asyncio
+
+from llmhive.app.orchestrator import Orchestrator
+from llmhive.app.services.base import (
+    LLMProvider,
+    LLMResult,
+    ProviderNotConfiguredError,
+)
+from llmhive.app.services.stub_provider import StubProvider
+
+
+class FailingProvider:
+    """Provider stub that always raises to simulate misconfiguration."""
+
+    def list_models(self) -> list[str]:
+        return ["gpt-4o"]
+
+    async def complete(self, prompt: str, *, model: str) -> LLMResult:  # pragma: no cover - interface requirement
+        raise ProviderNotConfiguredError("simulated failure")
+
+    async def critique(
+        self,
+        subject: str,
+        *,
+        target_answer: str,
+        author: str,
+        model: str,
+    ) -> LLMResult:  # pragma: no cover - interface requirement
+        raise ProviderNotConfiguredError("simulated failure")
+
+    async def improve(
+        self,
+        subject: str,
+        *,
+        previous_answer: str,
+        critiques: list[str],
+        model: str,
+    ) -> LLMResult:  # pragma: no cover - interface requirement
+        raise ProviderNotConfiguredError("simulated failure")
+
+
+def test_orchestrator_falls_back_to_stub_when_synthesis_provider_fails() -> None:
+    providers: dict[str, LLMProvider] = {
+        "openai": FailingProvider(),
+        "stub": StubProvider(seed=1234),
+    }
+    orchestrator = Orchestrator(providers=providers)
+
+    artifacts = asyncio.run(
+        orchestrator.orchestrate(
+            "What is the capital of Spain?",
+            models=["gpt-4o"],
+        )
+    )
+
+    assert "Madrid" in artifacts.final_response.content
+    assert artifacts.final_response.model == "stub-fallback(gpt-4o)"


### PR DESCRIPTION
## Summary
- guard the stub-only detection so it only fires when at least one initial response exists
- add a regression test that simulates total provider failure and confirms the API still returns a stub synthesis response

## Testing
- pytest llmhive/tests/test_api.py
- pytest llmhive/tests/test_orchestrator_stub_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_690217575550832b8b271c27eb599e53