### PR TITLE
Improve stub orchestration responses for city and coding prompts

### DIFF
--- a/llmhive/src/llmhive/app/services/stub_provider.py
+++ b/llmhive/src/llmhive/app/services/stub_provider.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import asyncio
 import random
-from typing import List
+import re
+from typing import List, Sequence, Tuple
 
 from .base import LLMProvider, LLMResult
 
@@ -17,12 +18,125 @@ class StubProvider(LLMProvider):
     def __init__(self, seed: int | None = None) -> None:
         self.random = random.Random(seed)
         self._models: List[str] = ["stub-v1", "stub-researcher", "stub-critic"]
+        self._number_words = {
+            "one": 1,
+            "two": 2,
+            "three": 3,
+            "four": 4,
+            "five": 5,
+            "six": 6,
+            "seven": 7,
+            "eight": 8,
+            "nine": 9,
+            "ten": 10,
+        }
+        # Data is intentionally small and human curated so we don't pull in external dependencies
+        # or APIs for the development stub provider.
+        self._city_data: dict[str, List[Tuple[str, str | None]]] = {
+            "europe": [
+                ("Istanbul, Turkey", "15.8M"),
+                ("Moscow, Russia", "12.5M"),
+                ("London, United Kingdom", "9.5M"),
+                ("Saint Petersburg, Russia", "5.4M"),
+                ("Berlin, Germany", "3.6M"),
+                ("Madrid, Spain", "3.3M"),
+                ("Kiev, Ukraine", "2.9M"),
+                ("Rome, Italy", "2.8M"),
+                ("Bucharest, Romania", "1.8M"),
+                ("Paris, France", "2.1M"),
+            ],
+            "world": [
+                ("Tokyo, Japan", "37.4M"),
+                ("Delhi, India", "32.9M"),
+                ("Shanghai, China", "29.2M"),
+                ("São Paulo, Brazil", "22.6M"),
+                ("Mexico City, Mexico", "22.2M"),
+                ("Cairo, Egypt", "22.1M"),
+                ("Dhaka, Bangladesh", "22.0M"),
+                ("Mumbai, India", "21.3M"),
+                ("Beijing, China", "20.9M"),
+                ("Osaka, Japan", "19.0M"),
+            ],
+            "spain": [
+                ("Madrid", "3.2M"),
+                ("Barcelona", "1.6M"),
+                ("Valencia", "0.8M"),
+                ("Seville (Sevilla)", "0.7M"),
+                ("Zaragoza", "0.7M"),
+                ("Málaga", "0.6M"),
+                ("Murcia", "0.5M"),
+                ("Palma de Mallorca", "0.4M"),
+                ("Las Palmas de Gran Canaria", "0.4M"),
+                ("Bilbao", "0.35M"),
+            ],
+            "usa": [
+                ("New York City, New York", "8.8M"),
+                ("Los Angeles, California", "3.9M"),
+                ("Chicago, Illinois", "2.7M"),
+                ("Houston, Texas", "2.3M"),
+                ("Phoenix, Arizona", "1.6M"),
+                ("Philadelphia, Pennsylvania", "1.6M"),
+                ("San Antonio, Texas", "1.5M"),
+                ("San Diego, California", "1.4M"),
+                ("Dallas, Texas", "1.3M"),
+                ("San Jose, California", "1.0M"),
+            ],
+            "florida": [
+                ("Jacksonville", "954K"),
+                ("Miami", "449K"),
+                ("Tampa", "399K"),
+                ("Orlando", "312K"),
+                ("St. Petersburg", "259K"),
+                ("Hialeah", "221K"),
+                ("Port St. Lucie", "217K"),
+                ("Cape Coral", "212K"),
+                ("Tallahassee", "197K"),
+                ("Fort Lauderdale", "183K"),
+            ],
+        }
 
     def list_models(self) -> List[str]:
         return list(self._models)
 
     async def _sleep(self) -> None:
         await asyncio.sleep(self.random.uniform(0.01, 0.05))
+
+    def _extract_requested_count(self, prompt_lower: str) -> int | None:
+        """Attempt to extract the desired number of items from the prompt."""
+        # Look for explicit numbers first (e.g. "list the 3 largest")
+        number_match = re.search(r"\b(\d{1,2})\b", prompt_lower)
+        if number_match:
+            try:
+                return int(number_match.group(1))
+            except ValueError:
+                pass
+
+        # Fall back to written number words up to ten
+        for word, value in self._number_words.items():
+            if re.search(rf"\b{word}\b", prompt_lower):
+                return value
+
+        return None
+
+    def _format_city_list(
+        self,
+        cities: Sequence[Tuple[str, str | None]],
+        count: int | None,
+        include_population: bool,
+        *,
+        default: int,
+        label: str,
+    ) -> str:
+        total = count or default
+        total = max(1, min(total, len(cities)))
+        lines = [
+            f"{idx}. {name}{f' — population {population}' if include_population and population else ''}"
+            for idx, (name, population) in enumerate(cities[:total], start=1)
+        ]
+        header = f"Here are the {total} largest cities in {label}:"
+        if include_population:
+            header += " (with approximate populations)"
+        return header + "\n" + "\n".join(lines)
 
     def _generate_answer(self, prompt: str) -> str:
         """Generate a simple, plausible answer based on the prompt.
@@ -90,39 +204,68 @@ class StubProvider(LLMProvider):
         
         # List questions about cities
         if "list" in prompt_lower or "largest" in prompt_lower or "biggest" in prompt_lower:
-            if ("europe" in prompt_lower or "european" in prompt_lower) and ("city" in prompt_lower or "cities" in prompt_lower):
-                return """Here are Europe's 5 largest cities by population:
-1. Istanbul, Turkey
-2. Moscow, Russia
-3. London, United Kingdom
-4. Saint Petersburg, Russia
-5. Berlin, Germany"""
-            elif ("world" in prompt_lower or "global" in prompt_lower) and ("city" in prompt_lower or "cities" in prompt_lower):
-                return """Here are the world's 5 largest cities by population:
-1. Tokyo, Japan
-2. Delhi, India
-3. Shanghai, China
-4. São Paulo, Brazil
-5. Mexico City, Mexico"""
-            elif "spain" in prompt_lower and ("city" in prompt_lower or "cities" in prompt_lower):
-                return """Here are Spain's 10 largest cities by population:
-1. Madrid
-2. Barcelona
-3. Valencia
-4. Seville (Sevilla)
-5. Zaragoza
-6. Málaga
-7. Murcia
-8. Palma de Mallorca
-9. Las Palmas de Gran Canaria
-10. Bilbao"""
-            elif ("usa" in prompt_lower or "united states" in prompt_lower or "american" in prompt_lower or " us " in prompt_lower or prompt_lower.startswith("us ") or prompt_lower.endswith(" us")) and ("city" in prompt_lower or "cities" in prompt_lower):
-                return """Here are the 5 largest cities in the United States by population:
-1. New York City, New York
-2. Los Angeles, California
-3. Chicago, Illinois
-4. Houston, Texas
-5. Phoenix, Arizona"""
+            if "city" in prompt_lower or "cities" in prompt_lower:
+                requested_count = self._extract_requested_count(prompt_lower)
+                include_population = "population" in prompt_lower or "populations" in prompt_lower
+
+                if "florida" in prompt_lower:
+                    return self._format_city_list(
+                        self._city_data["florida"],
+                        requested_count,
+                        include_population,
+                        default=5,
+                        label="Florida",
+                    )
+
+                if "spain" in prompt_lower:
+                    return self._format_city_list(
+                        self._city_data["spain"],
+                        requested_count,
+                        include_population,
+                        default=5,
+                        label="Spain",
+                    )
+
+                if "europe" in prompt_lower or "european" in prompt_lower:
+                    return self._format_city_list(
+                        self._city_data["europe"],
+                        requested_count,
+                        include_population,
+                        default=5,
+                        label="Europe",
+                    )
+
+                if "world" in prompt_lower or "global" in prompt_lower:
+                    return self._format_city_list(
+                        self._city_data["world"],
+                        requested_count,
+                        include_population,
+                        default=5,
+                        label="the world",
+                    )
+
+                if (
+                    "usa" in prompt_lower
+                    or "united states" in prompt_lower
+                    or "american" in prompt_lower
+                    or " us " in prompt_lower
+                    or prompt_lower.startswith("us ")
+                    or prompt_lower.endswith(" us")
+                ):
+                    return self._format_city_list(
+                        self._city_data["usa"],
+                        requested_count,
+                        include_population,
+                        default=5,
+                        label="the United States",
+                    )
+
+        if "best" in prompt_lower and "model" in prompt_lower and "coding" in prompt_lower:
+            return (
+                "Top AI coding assistants today include GPT-4.1 (OpenAI), Claude 3 Opus (Anthropic), and Gemini 1.5 Pro (Google). "
+                "Each excels at complex reasoning, tool use, and code synthesis, so the best choice depends on your language, "
+                "infrastructure, and budget requirements."
+            )
         
         # General questions - provide a generic but helpful response
         return f"This is a stub response. The question '{prompt[:MAX_PROMPT_PREVIEW_LENGTH]}' would normally be answered by a real LLM provider. Please configure API keys for OpenAI, Anthropic, or other providers to get actual AI responses."


### PR DESCRIPTION
## Summary
- enhance the stub provider to respect requested list sizes, add population-aware city datasets, and answer common coding-model questions
- update orchestration tests to cover new city list scenarios, Florida population responses, and coding model recommendations

## Testing
- pytest llmhive/tests/test_list_cities_issue.py

------
https://chatgpt.com/codex/tasks/task_e_690261a4eca0832b92d6774f6f18be82