### PR TITLE
Detect stub placeholders when providers misbehave

### DIFF
--- a/llmhive/src/llmhive/app/services/stub_provider.py
+++ b/llmhive/src/llmhive/app/services/stub_provider.py
@@ -15,6 +15,25 @@ MAX_PROMPT_PREVIEW_LENGTH = 100
 class StubProvider(LLMProvider):
     """Simple provider that fabricates plausible responses."""
 
+    _STUB_SIGNATURE = "this is a stub response"
+
+    @staticmethod
+    def is_stub_content(content: str | None) -> bool:
+        """Return ``True`` when *content* appears to be a stub placeholder."""
+
+        if not isinstance(content, str):
+            return False
+
+        normalized = content.strip().lower()
+        if not normalized:
+            return False
+
+        if normalized.startswith(StubProvider._STUB_SIGNATURE):
+            return True
+
+        # Legacy stub format used by earlier builds: "[model] Response to: ..."
+        return normalized.startswith("[") and " response to:" in normalized
+
     def __init__(self, seed: int | None = None) -> None:
         self.random = random.Random(seed)
         self._models: List[str] = ["stub-v1", "stub-researcher", "stub-critic"]


### PR DESCRIPTION
## Summary
- add a reusable helper on the stub provider to detect placeholder content
- fail the orchestration API when initial or final results are stubbed despite real providers being present
- cover the regression with an API test that forces a misconfigured provider

## Testing
- pytest tests/test_api.py::test_orchestrate_endpoint_fails_when_stub_content_detected


------
https://chatgpt.com/codex/tasks/task_e_6902aaeda8e0832ba1c683bea8a9bba5