### PR TITLE
Refresh UI layout and add Grok option

### DIFF
--- a/ui/app/components/PromptForm.module.css
+++ b/ui/app/components/PromptForm.module.css
@@ -9,22 +9,11 @@
 .commanderPanel,
 .resultSection {
   position: relative;
-  background: rgba(9, 11, 18, 0.78);
-  border: 1px solid rgba(129, 167, 231, 0.22);
-  border-radius: 22px;
-  padding: 2.25rem;
-  box-shadow: 0 30px 90px -45px rgba(8, 16, 32, 0.95);
-  backdrop-filter: blur(22px);
-}
-
-.commanderPanel::before,
-.resultSection::before {
-  content: "";
-  position: absolute;
-  inset: 1px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 20px;
-  border: 1px solid rgba(90, 163, 255, 0.1);
-  pointer-events: none;
+  padding: 2rem;
+  box-shadow: 0 20px 60px -40px rgba(15, 23, 42, 0.35);
 }
 
 .sectionHeader h2,
@@ -32,10 +21,11 @@
   font-size: 1.45rem;
   font-weight: 700;
   margin-bottom: 0.45rem;
+  color: #111827;
 }
 
 .sectionHeader p {
-  color: rgba(198, 210, 238, 0.75);
+  color: #4b5563;
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.55;
@@ -61,11 +51,11 @@
 }
 
 .label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: rgba(159, 198, 255, 0.88);
+  color: #6b7280;
 }
 
 .dropdown {
@@ -76,9 +66,9 @@
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(129, 167, 231, 0.38);
-  background: rgba(13, 16, 27, 0.85);
-  color: #f4f7ff;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
   font-size: 0.95rem;
   text-align: left;
   cursor: pointer;
@@ -88,8 +78,8 @@
 .dropdownToggle:hover:not(:disabled),
 .dropdownToggle:focus-visible {
   outline: none;
-  border-color: rgba(90, 163, 255, 0.9);
-  box-shadow: 0 0 0 3px rgba(90, 163, 255, 0.25);
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.12);
   transform: translateY(-1px);
 }
 
@@ -99,16 +89,16 @@
   left: 0;
   right: 0;
   z-index: 12;
-  background: rgba(10, 13, 22, 0.97);
+  background: #ffffff;
   border-radius: 16px;
-  border: 1px solid rgba(114, 150, 217, 0.35);
+  border: 1px solid #d1d5db;
   padding: 1.1rem;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
   max-height: 340px;
   overflow-y: auto;
-  box-shadow: 0 30px 60px -35px rgba(0, 0, 0, 0.75);
+  box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.25);
 }
 
 .dropdownOption {
@@ -116,12 +106,12 @@
   gap: 0.75rem;
   align-items: flex-start;
   cursor: pointer;
-  color: rgba(236, 243, 255, 0.95);
+  color: #111827;
 }
 
 .dropdownOption input {
   margin-top: 0.3rem;
-  accent-color: #7f5aff;
+  accent-color: #111827;
 }
 
 .dropdownOptionLabel {
@@ -132,14 +122,14 @@
 .dropdownOptionDescription {
   display: block;
   font-size: 0.8rem;
-  color: rgba(182, 197, 229, 0.72);
+  color: #6b7280;
   margin-top: 0.2rem;
 }
 
 .dropdownHint {
   font-size: 0.75rem;
-  color: rgba(150, 168, 210, 0.65);
-  border-top: 1px solid rgba(114, 150, 217, 0.25);
+  color: #6b7280;
+  border-top: 1px solid #e5e7eb;
   padding-top: 0.6rem;
   margin-top: 0.2rem;
 }
@@ -152,9 +142,9 @@
 }
 
 .chip {
-  background: linear-gradient(135deg, rgba(90, 163, 255, 0.28), rgba(127, 90, 255, 0.18));
-  border: 1px solid rgba(127, 90, 255, 0.35);
-  color: #f1f4ff;
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+  color: #111827;
   border-radius: 999px;
   padding: 0.35rem 0.85rem;
   font-size: 0.78rem;
@@ -163,7 +153,7 @@
 
 .strategyDescription {
   font-size: 0.88rem;
-  color: rgba(198, 210, 238, 0.72);
+  color: #4b5563;
   line-height: 1.6;
 }
 
@@ -172,9 +162,9 @@
   min-height: 210px;
   padding: 1.35rem;
   border-radius: 18px;
-  border: 1px solid rgba(129, 167, 231, 0.28);
-  background: rgba(8, 10, 18, 0.85);
-  color: #f6f9ff;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
   font-size: 1rem;
   line-height: 1.65;
   resize: vertical;
@@ -183,8 +173,8 @@
 
 .textarea:focus {
   outline: none;
-  border-color: rgba(90, 163, 255, 0.8);
-  box-shadow: 0 0 0 3px rgba(90, 163, 255, 0.25);
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.12);
 }
 
 .formFooter {
@@ -201,16 +191,16 @@
   gap: 0.45rem;
   padding: 0.95rem 1.1rem;
   border-radius: 16px;
-  background: rgba(13, 17, 28, 0.82);
-  border: 1px solid rgba(114, 150, 217, 0.25);
-  color: rgba(231, 237, 255, 0.95);
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  color: #111827;
 }
 
 .summaryTitle {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(159, 198, 255, 0.9);
+  color: #6b7280;
 }
 
 .summaryList {
@@ -226,18 +216,21 @@
   padding: 0.95rem 1.8rem;
   border-radius: 16px;
   border: none;
-  background: linear-gradient(135deg, #5aa3ff, #7f5aff);
+  background: #111827;
   color: #ffffff;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   min-width: 220px;
 }
 
-.button:hover:not(:disabled) {
+.button:hover:not(:disabled),
+.button:focus-visible {
+  outline: none;
   transform: translateY(-1px);
-  box-shadow: 0 20px 35px -22px rgba(90, 163, 255, 0.65);
+  background: #1f2937;
+  box-shadow: 0 20px 35px -22px rgba(15, 23, 42, 0.45);
 }
 
 .button:disabled {
@@ -246,9 +239,9 @@
 }
 
 .error {
-  color: #ff9b9b;
-  background-color: rgba(179, 53, 53, 0.16);
-  border: 1px solid rgba(255, 133, 133, 0.4);
+  color: #b91c1c;
+  background-color: #fee2e2;
+  border: 1px solid #fecaca;
   border-radius: 16px;
   padding: 1rem 1.25rem;
 }
@@ -265,7 +258,7 @@
   right: 1.5rem;
   height: 4px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(90, 163, 255, 0.18), rgba(127, 90, 255, 0.42));
+  background: #e5e7eb;
   overflow: hidden;
 }
 
@@ -275,7 +268,7 @@
   top: 0;
   bottom: 0;
   width: 35%;
-  background: linear-gradient(90deg, rgba(90, 163, 255, 0.35), rgba(127, 90, 255, 0.7));
+  background: linear-gradient(90deg, rgba(17, 24, 39, 0.15), rgba(17, 24, 39, 0.55));
   border-radius: 999px;
   animation: shimmer 1.4s infinite;
 }
@@ -290,12 +283,12 @@
 }
 
 .resultPre {
-  background: rgba(8, 11, 18, 0.88);
-  border: 1px solid rgba(114, 150, 217, 0.3);
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
   border-radius: 18px;
   padding: 1.6rem;
   min-height: 220px;
-  color: #f4f7ff;
+  color: #111827;
   white-space: pre-wrap;
   word-break: break-word;
   font-family: "JetBrains Mono", "Fira Code", monospace;

--- a/ui/app/components/PromptForm.tsx
+++ b/ui/app/components/PromptForm.tsx
@@ -49,6 +49,16 @@ const MODEL_OPTIONS: Option[] = [
     label: "Gemini 1.5 Pro (Google)",
     description: "Multimodal powerhouse with research-grade recall.",
   },
+  {
+    value: "grok-beta",
+    label: "Grok Beta (xAI)",
+    description: "Edgy reasoning with real-time awareness of the wider world.",
+  },
+  {
+    value: "llmhive-ensemble",
+    label: "LLMHive Ensemble",
+    description: "Balanced collective that routes prompts to the best-fit model automatically.",
+  },
 ];
 
 const STRATEGY_OPTIONS: StrategyOption[] = [

--- a/ui/app/components/Sidebar.module.css
+++ b/ui/app/components/Sidebar.module.css
@@ -1,41 +1,40 @@
 .sidebar {
-  position: relative;
   width: 300px;
   min-width: 280px;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1.75rem 1.5rem 1.75rem 1.25rem;
-  background: linear-gradient(180deg, rgba(11, 12, 20, 0.96), rgba(8, 9, 15, 0.92));
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  color: #e7ecfa;
+  gap: 1.75rem;
+  padding: 2rem 1.75rem;
+  background: #f9fafb;
+  border-right: 1px solid #e5e7eb;
+  color: #111827;
   transition: width 0.25s ease, min-width 0.25s ease;
 }
 
 .collapsed {
   width: 96px;
   min-width: 96px;
+  padding: 2rem 1rem;
 }
 
 .brandRow {
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  padding: 0 0.35rem;
 }
 
 .collapseButton {
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
-  gap: 0.3rem;
+  gap: 0.28rem;
   width: 44px;
   height: 44px;
   border-radius: 12px;
-  border: 1px solid rgba(151, 173, 227, 0.35);
-  background: rgba(16, 19, 30, 0.8);
+  border: 1px solid #d1d5db;
+  background: #ffffff;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .collapseButton span {
@@ -43,21 +42,24 @@
   height: 2px;
   width: 18px;
   margin: 0 auto;
-  background: linear-gradient(90deg, #5aa3ff, #7f5aff);
+  background: #111827;
   border-radius: 999px;
 }
 
-.collapseButton:hover {
-  border-color: #5aa3ff;
+.collapseButton:hover,
+.collapseButton:focus-visible {
+  outline: none;
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.12);
   transform: translateY(-1px);
 }
 
 .brand {
-  font-size: 1.3rem;
+  font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #9fc6ff;
+  color: #111827;
 }
 
 .collapsed .brand {
@@ -70,13 +72,13 @@
   gap: 0.75rem;
   padding: 0.9rem 1.1rem;
   border-radius: 14px;
-  border: 1px solid rgba(90, 163, 255, 0.4);
-  background: linear-gradient(135deg, rgba(90, 163, 255, 0.22), rgba(127, 90, 255, 0.2));
-  color: #f4f7ff;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
   font-weight: 600;
   cursor: pointer;
   text-align: left;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .newChatButton svg {
@@ -86,9 +88,12 @@
   fill: none;
 }
 
-.newChatButton:hover {
+.newChatButton:hover,
+.newChatButton:focus-visible {
+  outline: none;
+  border-color: #111827;
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.35);
   transform: translateY(-1px);
-  box-shadow: 0 16px 28px -20px rgba(90, 163, 255, 0.6);
 }
 
 .collapsed .newChatButton span {
@@ -119,12 +124,12 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(159, 198, 255, 0.7);
+  color: #6b7280;
 }
 
 .section ul {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.45rem;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -135,20 +140,21 @@
   align-items: center;
   gap: 0.85rem;
   width: 100%;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 14px;
   padding: 0.75rem 0.9rem;
-  background: rgba(18, 21, 32, 0.65);
+  background: transparent;
   color: inherit;
   text-align: left;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
 }
 
 .navItem:hover,
 .navItem:focus-visible {
   outline: none;
-  background: rgba(90, 163, 255, 0.16);
+  border-color: #d1d5db;
+  background: #ffffff;
   transform: translateX(3px);
 }
 
@@ -159,8 +165,8 @@
   width: 36px;
   height: 36px;
   border-radius: 12px;
-  background: rgba(20, 24, 38, 0.9);
-  border: 1px solid rgba(111, 147, 214, 0.2);
+  background: #eef2f7;
+  border: 1px solid #e5e7eb;
 }
 
 .icon svg {
@@ -168,7 +174,7 @@
   height: 18px;
   stroke: currentColor;
   fill: none;
-  opacity: 0.88;
+  opacity: 0.9;
 }
 
 .navCopy {
@@ -183,8 +189,8 @@
 }
 
 .navCopy small {
-  font-size: 0.75rem;
-  color: rgba(195, 207, 234, 0.7);
+  font-size: 0.78rem;
+  color: #6b7280;
 }
 
 .collapsed .navCopy {
@@ -200,11 +206,10 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  background: rgba(18, 21, 32, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 0 0 1px rgba(90, 163, 255, 0.08);
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
 }
 
 .avatar {
@@ -216,9 +221,8 @@
   justify-content: center;
   font-weight: 700;
   letter-spacing: 0.04em;
-  background: radial-gradient(circle at 30% 30%, rgba(90, 163, 255, 0.45), rgba(15, 18, 28, 0.95));
-  border: 1px solid rgba(90, 163, 255, 0.4);
-  color: #f2f6ff;
+  background: #111827;
+  color: #ffffff;
 }
 
 .profileCopy {
@@ -228,13 +232,14 @@
 }
 
 .profileName {
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
+  color: #111827;
 }
 
 .profileCopy small {
-  font-size: 0.75rem;
-  color: rgba(182, 197, 229, 0.7);
+  font-size: 0.78rem;
+  color: #6b7280;
 }
 
 .collapsed .profileCopy {
@@ -247,16 +252,11 @@
     min-width: auto;
     flex-direction: row;
     align-items: center;
-    gap: 1.25rem;
-    padding: 1.25rem 1.5rem;
+    gap: 1.5rem;
+    padding: 1.5rem;
     border-right: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: 0 18px 40px -32px rgba(0, 0, 0, 0.8);
-    position: relative;
-  }
-
-  .brandRow {
-    padding: 0;
+    border-bottom: 1px solid #e5e7eb;
+    box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.25);
   }
 
   .sectionList {
@@ -268,7 +268,7 @@
   }
 
   .section {
-    min-width: 200px;
+    min-width: 220px;
   }
 
   .profileCard {

--- a/ui/app/page.module.css
+++ b/ui/app/page.module.css
@@ -1,168 +1,162 @@
 .shell {
   display: flex;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(70, 91, 255, 0.18), transparent 65%),
-    radial-gradient(circle at bottom, rgba(127, 90, 255, 0.12), transparent 45%),
-    #04050b;
-  color: #f5f8ff;
+  background: #ffffff;
+  color: #111827;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .canvas {
-  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 2.5rem 3rem 3rem;
-  overflow: hidden;
-}
-
-.backdrop {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-}
-
-.glassOrb {
-  width: min(32vw, 320px);
-  height: min(32vw, 320px);
-  border-radius: 50%;
-  background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.45), rgba(90, 163, 255, 0.06));
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  box-shadow: inset 0 40px 70px rgba(255, 255, 255, 0.15), inset 0 -30px 60px rgba(90, 163, 255, 0.25);
-  filter: blur(0.2px);
-  opacity: 0.5;
-  mix-blend-mode: screen;
-}
-
-.glowRing {
-  position: absolute;
-  width: min(45vw, 460px);
-  height: min(45vw, 460px);
-  border-radius: 50%;
-  border: 1px solid rgba(90, 163, 255, 0.25);
-  box-shadow: 0 0 120px rgba(90, 163, 255, 0.12);
-  opacity: 0.3;
-  animation: slowPulse 9s ease-in-out infinite;
-}
-
-@keyframes slowPulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.28;
-  }
-  50% {
-    transform: scale(1.05);
-    opacity: 0.4;
-  }
+  padding: 2.5rem 3rem;
+  background: #ffffff;
 }
 
 .hero {
-  position: relative;
-  z-index: 1;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 2rem;
   padding-bottom: 2rem;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .heroCopy {
-  max-width: 620px;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.6rem;
+  max-width: 640px;
+}
+
+.breadcrumb {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #6b7280;
 }
 
 .title {
-  font-size: clamp(2.5rem, 3.8vw, 3.3rem);
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
 }
 
 .subtitle {
-  color: rgba(168, 189, 231, 0.78);
+  color: #4b5563;
   font-size: 1.05rem;
   line-height: 1.6;
-  max-width: 540px;
+  margin: 0;
 }
 
 .userInfo {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
   gap: 0.75rem;
+  align-items: flex-end;
 }
 
 .userGreeting {
   font-size: 0.9rem;
-  letter-spacing: 0.04em;
+  color: #4b5563;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(159, 198, 255, 0.85);
 }
 
 .authButton {
-  padding: 0.65rem 1.6rem;
+  padding: 0.65rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid rgba(154, 191, 249, 0.35);
-  background: rgba(13, 17, 28, 0.85);
-  color: #f5f8ff;
+  border: 1px solid #d1d5db;
+  background: #111827;
+  color: #ffffff;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .authButton:hover,
 .authButton:focus-visible {
-  border-color: rgba(90, 163, 255, 0.9);
-  box-shadow: 0 0 0 3px rgba(90, 163, 255, 0.25);
+  outline: none;
+  background: #1f2937;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.15);
+}
+
+.menuRow {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.25rem 0 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 1.5rem;
+}
+
+.menuButton {
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #4b5563;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.menuButton:hover,
+.menuButton:focus-visible {
+  outline: none;
+  color: #111827;
+  border-color: #d1d5db;
+  background: #f3f4f6;
+}
+
+.menuButtonActive {
+  color: #111827;
+  border-color: #111827;
+  background: #f3f4f6;
 }
 
 .content {
-  position: relative;
-  z-index: 1;
   flex: 1;
   display: flex;
   align-items: flex-start;
   justify-content: center;
+  padding-bottom: 3rem;
 }
 
 .loading {
   font-size: 1.05rem;
-  color: rgba(178, 193, 224, 0.8);
+  color: #4b5563;
   padding-top: 3rem;
 }
 
 .welcomePanel {
   max-width: 420px;
-  padding: 2.25rem 2.5rem;
+  padding: 2rem 2.5rem;
   border-radius: 20px;
-  background: rgba(8, 11, 18, 0.7);
-  border: 1px solid rgba(154, 191, 249, 0.25);
-  box-shadow: 0 28px 60px -40px rgba(8, 16, 32, 0.9);
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
   text-align: center;
+  box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.2);
 }
 
 .welcomePanel h2 {
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   margin-bottom: 1rem;
+  color: #111827;
 }
 
 .welcomePanel p {
-  color: rgba(180, 196, 226, 0.78);
+  color: #4b5563;
   font-size: 1rem;
-  line-height: 1.7;
+  line-height: 1.65;
 }
 
 .error {
-  color: #ff9b9b;
-  background-color: rgba(179, 53, 53, 0.16);
-  border: 1px solid rgba(255, 133, 133, 0.35);
-  border-radius: 18px;
+  color: #b91c1c;
+  background-color: #fee2e2;
+  border: 1px solid #fecaca;
+  border-radius: 16px;
   padding: 1.2rem 1.4rem;
 }
 
@@ -172,14 +166,13 @@
   }
 
   .canvas {
-    padding: 2rem 1.75rem 2.5rem;
+    padding: 2rem 1.75rem 3rem;
   }
-}
 
-@media (max-width: 780px) {
   .hero {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+    gap: 1.5rem;
   }
 
   .userInfo {
@@ -187,12 +180,16 @@
   }
 }
 
-@media (max-width: 620px) {
+@media (max-width: 720px) {
   .canvas {
-    padding: 1.75rem 1.4rem 2.5rem;
+    padding: 1.75rem 1.25rem 2.5rem;
   }
 
-  .welcomePanel {
-    padding: 1.9rem 1.8rem;
+  .menuRow {
+    flex-wrap: wrap;
+  }
+
+  .content {
+    justify-content: flex-start;
   }
 }

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -23,16 +23,14 @@ function SignIn() {
 function SignOut({ user }: { user: User }) {
   return (
     <div className={styles.userInfo}>
-      <span className={styles.userGreeting}>Welcome, {user?.name || "Innovator"}</span>
+      <span className={styles.userGreeting}>Signed in as {user?.name || "Innovator"}</span>
       <form
         action={async () => {
           "use server";
           await signOut();
         }}
       >
-        <button type="submit" className={styles.authButton}>
-          Sign Out
-        </button>
+        <button type="submit" className={styles.authButton}>Sign out</button>
       </form>
     </div>
   );
@@ -47,20 +45,31 @@ export default async function Home() {
       <main className={styles.shell}>
         <Sidebar displayName={user?.name ?? user?.email ?? null} />
         <div className={styles.canvas}>
-          <div className={styles.backdrop} aria-hidden="true">
-            <div className={styles.glassOrb} />
-            <div className={styles.glowRing} />
-          </div>
-
           <header className={styles.hero}>
             <div className={styles.heroCopy}>
+              <div className={styles.breadcrumb}>Dashboard • Compose</div>
               <h1 className={styles.title}>LLMHive Orchestration Studio</h1>
               <p className={styles.subtitle}>
-                Shape your next-generation collective of agents with a cockpit that nods to the latest frontier model experiences.
+                Shape your collective of models, reasoning modes, and workflows in an interface inspired by the flagship LLM chat experiences.
               </p>
             </div>
             <div>{user ? <SignOut user={user} /> : <SignIn />}</div>
           </header>
+
+          <nav className={styles.menuRow} aria-label="Primary">
+            <button className={`${styles.menuButton} ${styles.menuButtonActive}`} type="button">
+              Compose
+            </button>
+            <button className={styles.menuButton} type="button">
+              Evaluations
+            </button>
+            <button className={styles.menuButton} type="button">
+              Activity
+            </button>
+            <button className={styles.menuButton} type="button">
+              Playground
+            </button>
+          </nav>
 
           <div className={styles.content}>
             {user ? (
@@ -85,12 +94,9 @@ export default async function Home() {
       <main className={styles.shell}>
         <Sidebar displayName={null} />
         <div className={styles.canvas}>
-          <div className={styles.backdrop} aria-hidden="true">
-            <div className={styles.glassOrb} />
-            <div className={styles.glowRing} />
-          </div>
           <header className={styles.hero}>
             <div className={styles.heroCopy}>
+              <div className={styles.breadcrumb}>Dashboard • Compose</div>
               <h1 className={styles.title}>LLMHive Orchestration Studio</h1>
               <p className={styles.subtitle}>Experience next-generation collaborative intelligence.</p>
             </div>


### PR DESCRIPTION
## Summary
- restyle the landing canvas and sidebar with a white, app-like layout inspired by flagship LLM chat clients
- refresh the orchestration form styling to match the lighter aesthetic and improve menu affordances
- add Grok and LLMHive Ensemble model choices to the selectable provider list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69030b919784832b87a100b9f3bfadaf