### PR TITLE
Add google-generativeai dependency

### DIFF
--- a/llmhive/requirements.txt
+++ b/llmhive/requirements.txt
@@ -10,3 +10,4 @@ openai>=1.12.0
 httpx>=0.26
 tenacity>=8.2
 psycopg[binary]>=3.1
+google-generativeai>=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ google-cloud-aiplatform
 pydantic-settings
 python-json-logger
 google-cloud-secret-manager
+google-generativeai


### PR DESCRIPTION
## Summary
- add the missing google-generativeai dependency to the root requirements
- ensure the llmhive package requirements also include google-generativeai for Gemini provider support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690541eb7d48832b91464c7b532dfedf