### PR TITLE
Add stub response for affluent Miami-Dade city list

### DIFF
--- a/llmhive/src/llmhive/app/services/stub_provider.py
+++ b/llmhive/src/llmhive/app/services/stub_provider.py
@@ -113,6 +113,20 @@ class StubProvider(LLMProvider):
                 ("Fort Lauderdale", "183K"),
             ],
         }
+        self._affluent_city_data: dict[str, List[Tuple[str, str]]] = {
+            "miami-dade": [
+                ("Golden Beach", "median household income about $216K"),
+                ("Key Biscayne", "median household income about $167K"),
+                ("Pinecrest", "median household income about $157K"),
+                ("Bal Harbour", "median household income about $138K"),
+                ("Palmetto Bay", "median household income about $121K"),
+                ("Coral Gables", "median household income about $111K"),
+                ("Bay Harbor Islands", "median household income about $108K"),
+                ("Surfside", "median household income about $104K"),
+                ("Aventura", "median household income about $82K"),
+                ("Miami Lakes", "median household income about $89K"),
+            ]
+        }
         self._affordable_developer_data: dict[str, List[Tuple[str, str, str]]] = {
             "florida": [
                 (
@@ -189,6 +203,23 @@ class StubProvider(LLMProvider):
         header = f"Here are the {total} largest cities in {label}:"
         if include_population:
             header += " (with approximate populations)"
+        return header + "\n" + "\n".join(lines)
+
+    def _format_affluent_city_list(
+        self,
+        cities: Sequence[Tuple[str, str]],
+        count: int | None,
+        *,
+        default: int,
+        region_label: str,
+    ) -> str:
+        total = count or default
+        total = max(1, min(total, len(cities)))
+        lines = [
+            f"{idx}. {name} — {income}"
+            for idx, (name, income) in enumerate(cities[:total], start=1)
+        ]
+        header = f"Here are {total} affluent cities in {region_label}:"
         return header + "\n" + "\n".join(lines)
 
     def _format_developer_list(
@@ -278,6 +309,26 @@ class StubProvider(LLMProvider):
                     count,
                     default=5,
                     region_label="Florida",
+                )
+
+        if (
+            "miami" in prompt_lower
+            and "dade" in prompt_lower
+            and (
+                "affluent" in prompt_lower
+                or "wealth" in prompt_lower
+                or "rich" in prompt_lower
+                or "wealthiest" in prompt_lower
+            )
+        ):
+            count = self._extract_requested_count(prompt_lower)
+            cities = self._affluent_city_data.get("miami-dade", [])
+            if cities:
+                return self._format_affluent_city_list(
+                    cities,
+                    count,
+                    default=10,
+                    region_label="Miami-Dade County, Florida",
                 )
 
         # Capital city questions

--- a/llmhive/tests/test_list_cities_issue.py
+++ b/llmhive/tests/test_list_cities_issue.py
@@ -136,3 +136,31 @@ def test_affordable_housing_developers_in_florida(client):
     assert "stub response" not in final_content.lower()
     assert "affordable" in final_content.lower()
     assert "Florida" in final_content
+
+
+def test_affluent_miami_dade_cities(client):
+    payload = OrchestrationRequest(
+        prompt="List the 10 most affluent cities in Miami Dade county Florida",
+        models=["gpt-4"],
+    )
+    response = client.post("/api/v1/orchestration/", json=payload.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+    content = data["initial_responses"][0]["content"]
+
+    assert "stub response" not in content.lower()
+    assert "miami-dade county" in content.lower()
+    assert "affluent" in content.lower()
+
+    lines = [line for line in content.splitlines() if line.strip() and line.strip()[0].isdigit()]
+    assert len(lines) == 10, f"Expected 10 affluent cities, got {len(lines)}: {content}"
+
+    for city in [
+        "Pinecrest",
+        "Key Biscayne",
+        "Coral Gables",
+        "Palmetto Bay",
+        "Bal Harbour",
+    ]:
+        assert city in content, f"Expected {city} in affluent city list: {content}"


### PR DESCRIPTION
## Summary
- add a curated affluent city dataset and formatter to the stub provider for Miami-Dade County prompts
- route affluent Miami-Dade list questions to the new dataset so stub responses stay informative
- extend the list cities test suite with coverage for the affluent Miami-Dade request

## Testing
- pytest llmhive/tests/test_list_cities_issue.py

------
https://chatgpt.com/codex/tasks/task_e_690548a6e5a0832b8933005ea2036314