### PR TITLE
Align Gemini and Grok provider wiring across runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,25 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11-slim-buster
 
-# Set the working directory for the entire container.
+# Set the working directory for the container
 WORKDIR /app
 
-# Copy the application code from the repository root
-# into a 'src' directory inside the container.
-# This creates a clean project structure: /app/src/app, /app/src/config, etc.
-COPY app/ ./src/app/
-COPY main.py ./src/
-COPY models.yaml ./src/
-COPY requirements.txt ./src/
+# Copy dependency manifests first to leverage Docker layer caching
+COPY requirements.txt ./
+COPY llmhive/requirements.txt ./llmhive/requirements.txt
 
-# Install the Python dependencies from the requirements file now located at /app/src/requirements.txt
-RUN pip install --no-cache-dir -r src/requirements.txt
+# Install runtime dependencies for both the legacy app/ runtime and the
+# refactored llmhive/src package.  Keeping the installs separate makes the
+# layer cache friendlier when only one requirements file changes.
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir -r llmhive/requirements.txt
 
-#
-# --- THIS IS THE CRITICAL AND CORRECT CONFIGURATION ---
-#
-# Set the PYTHONPATH to our new source directory.
-# This tells the Python interpreter to look for modules inside /app/src.
-ENV PYTHONPATH="/app/src"
+# Copy the application code into the image
+COPY . .
 
-# Set the working directory to the source folder for the final command.
-WORKDIR /app/src
-# --- END OF CRITICAL CONFIGURATION ---
+# Ensure both the repository root (legacy layout) and the new
+# llmhive/src package directory are on the Python path.
+ENV PYTHONPATH="/app:/app/llmhive/src"
 
-# Command to run the application using Gunicorn.
-# Because our WORKDIR and PYTHONPATH are now correctly set to /app/src,
-# Gunicorn can correctly find the 'app' package, the 'main' module,
-# and the 'app' instance inside it.
+# Expose the FastAPI app via Gunicorn/Uvicorn
 CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT:-8080} main:app -k uvicorn.workers.UvicornWorker"]

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
     GEMINI_API_KEY: Optional[str] = None
+    GROK_API_KEY: Optional[str] = None
     TAVILY_API_KEY: Optional[str] = None
 
     # Model configuration

--- a/app/models/llm_provider.py
+++ b/app/models/llm_provider.py
@@ -5,7 +5,7 @@ import logging
 from typing import AsyncGenerator, Dict, List
 
 from app.config import settings
-from app.providers import GeminiProvider
+from app.providers import GeminiProvider, GrokProvider
 
 try:
     from openai import AsyncOpenAI
@@ -79,6 +79,7 @@ PROVIDER_CLASS_MAP = {
     "openai": (OpenAIProvider, settings.OPENAI_API_KEY),
     "anthropic": (AnthropicProvider, settings.ANTHROPIC_API_KEY),
     "google": (GeminiProvider, getattr(settings, "GEMINI_API_KEY", None)),
+    "xai": (GrokProvider, getattr(settings, "GROK_API_KEY", None)),
     "stub": (StubProvider, "stub"),
 }
 

--- a/app/models/model_pool.py
+++ b/app/models/model_pool.py
@@ -186,14 +186,14 @@ class ModelPool:
                 cost_per_token=0.005,
             ),
             ModelProfile(
-                model_id="gemini-pro",
+                model_id="gemini-1.5-pro",
                 provider="google",
                 strengths=["multimodal", "reasoning"],
                 context_window=128000,
                 cost_per_token=0.0025,
             ),
             ModelProfile(
-                model_id="grok-1",
+                model_id="grok-beta",
                 provider="xai",
                 strengths=["real-time-information", "humor"],
                 context_window=8192,

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -1,5 +1,6 @@
 """Provider implementations exposed by the lightweight app package."""
 
 from .gemini import GeminiProvider
+from .grok import GrokProvider
 
-__all__ = ["GeminiProvider"]
+__all__ = ["GeminiProvider", "GrokProvider"]

--- a/app/providers/grok.py
+++ b/app/providers/grok.py
@@ -1,0 +1,67 @@
+"""Grok provider for the lightweight runtime."""
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncGenerator, Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for typing
+    from app.models.llm_provider import LLMProvider as _BaseProvider
+else:  # pragma: no cover - runtime placeholder avoids circular import
+    class _BaseProvider:  # type: ignore[too-many-ancestors]
+        pass
+
+try:  # pragma: no cover - optional dependency for local dev
+    from openai import AsyncOpenAI  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully at runtime
+    AsyncOpenAI = None  # type: ignore
+
+logger = logging.getLogger("app.providers.grok")
+
+
+class GrokProvider(_BaseProvider):
+    """Interact with xAI's Grok models via the OpenAI-compatible API."""
+
+    _BASE_URL = "https://api.x.ai/v1"
+
+    def __init__(self, api_key: str, *, temperature: float = 0.6) -> None:
+        if not AsyncOpenAI:
+            raise ImportError("The 'openai' package is required to use the Grok provider.")
+        if not api_key:
+            raise ValueError("Grok API key must be provided.")
+
+        self._client = AsyncOpenAI(api_key=api_key, base_url=self._BASE_URL)
+        self._temperature = temperature
+
+    async def generate(self, messages: List[Dict[str, str]], model: str, **kwargs: Any) -> str:
+        try:
+            completion = await self._client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=kwargs.get("temperature", self._temperature),
+            )
+        except Exception as exc:  # pragma: no cover - network failure surface
+            logger.warning("Grok generate request failed: %s", exc)
+            return f"Error: Could not get response from {model}."
+
+        return completion.choices[0].message.content or ""
+
+    async def generate_stream(
+        self,
+        messages: List[Dict[str, str]],
+        model: str,
+        **kwargs: Any,
+    ) -> AsyncGenerator[str, None]:
+        try:
+            stream = await self._client.chat.completions.create(
+                model=model,
+                messages=messages,
+                stream=True,
+                temperature=kwargs.get("temperature", self._temperature),
+            )
+            async for chunk in stream:
+                content = chunk.choices[0].delta.content
+                if content:
+                    yield content
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Grok streaming request failed: %s", exc)
+            yield f"Error: Could not stream from {model}."

--- a/app/tests/test_model_pool_configuration.py
+++ b/app/tests/test_model_pool_configuration.py
@@ -29,8 +29,8 @@ def test_all_required_models_present():
         'gpt-4': 'openai',
         'claude-3-opus': 'anthropic',
         'claude-3-sonnet': 'anthropic',
-        'gemini-pro': 'google',
-        'grok-1': 'xai',
+        'gemini-1.5-pro': 'google',
+        'grok-beta': 'xai',
     }
     
     for model_id, expected_provider in expected_models.items():
@@ -44,25 +44,25 @@ def test_model_attributes():
     """Test that models have correct attributes."""
     pool = ModelPool()
     
-    # Test gemini-pro
-    gemini = pool.get_model_profile('gemini-pro')
+    # Test gemini-1.5-pro
+    gemini = pool.get_model_profile('gemini-1.5-pro')
     assert gemini is not None
     assert gemini.provider == 'google'
     assert 'multimodal' in gemini.strengths
     assert 'reasoning' in gemini.strengths
     assert gemini.context_window == 128000
     assert gemini.cost_per_token == 0.0025
-    print("✓ gemini-pro attributes correct")
-    
-    # Test grok-1
-    grok = pool.get_model_profile('grok-1')
+    print("✓ gemini-1.5-pro attributes correct")
+
+    # Test grok-beta
+    grok = pool.get_model_profile('grok-beta')
     assert grok is not None
     assert grok.provider == 'xai'
     assert 'real-time-information' in grok.strengths
     assert 'humor' in grok.strengths
     assert grok.context_window == 8192
     assert grok.cost_per_token == 0.01
-    print("✓ grok-1 attributes correct")
+    print("✓ grok-beta attributes correct")
 
 
 def test_default_models_fallback():

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,4 +50,8 @@ maybe_export_from_file "GEMINI_API_KEY"
 # Use PORT environment variable if set by Cloud Run, otherwise default to 8080
 PORT=${PORT:-8080}
 
-exec gunicorn --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT app:app
+# Guarantee the modern package layout is importable even in minimalist runtime
+# environments that do not honour the Dockerfile PYTHONPATH.
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd):$(pwd)/llmhive/src"
+
+exec gunicorn --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT main:app

--- a/llmhive/src/llmhive/app/api/orchestration.py
+++ b/llmhive/src/llmhive/app/api/orchestration.py
@@ -40,6 +40,9 @@ MODEL_ALIAS_MAP: dict[str, str] = {
     "claude-3-opus-latest": "claude-3-opus-20240229",
     "claude-3-sonnet": "claude-3-sonnet-20240229",
     "claude-3-sonnet-latest": "claude-3-sonnet-20240229",
+    "gemini-pro": "gemini-1.5-pro",
+    "gemini-1.0-pro": "gemini-1.5-pro",
+    "grok-1": "grok-beta",
 }
 
 logger = logging.getLogger(__name__)

--- a/llmhive/src/llmhive/app/main.py
+++ b/llmhive/src/llmhive/app/main.py
@@ -12,11 +12,12 @@ from .api import api_router
 from .database import engine
 from .models import Base
 
-# Configure comprehensive logging
+# Configure comprehensive logging as early as possible so that import-time
+# diagnostics (for example, when providers fail to configure) are captured.
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
 

--- a/models.yaml
+++ b/models.yaml
@@ -23,13 +23,13 @@ models:
     context_window: 200000
     cost_per_token: 0.005
 
-  - model_id: "gemini-pro"
+  - model_id: "gemini-1.5-pro"
     provider: "google"
     strengths: ["multimodal", "reasoning"]
     context_window: 128000
     cost_per_token: 0.0025
 
-  - model_id: "grok-1"
+  - model_id: "grok-beta"
     provider: "xai"
     strengths: ["real-time-information", "humor"]
     context_window: 8192


### PR DESCRIPTION
## Summary
- ensure the top-level entrypoint, Docker build, and entrypoint script load the refactored `llmhive` FastAPI app while keeping the legacy layout working
- add first-class Grok support to the lightweight runtime and align model metadata/aliases so Gemini and Grok IDs match the front end
- enhance the shared Gemini provider with model alias resolution and clearer SSL diagnostics

## Testing
- pytest app/tests/test_model_pool_configuration.py

------
https://chatgpt.com/codex/tasks/task_e_69055c1453ac832b95d902373c51e0a3