### PR TITLE
Normalize Gemini model aliases

### DIFF
--- a/llmhive/tests/test_provider_connectivity.py
+++ b/llmhive/tests/test_provider_connectivity.py
@@ -135,6 +135,27 @@ class TestGeminiProvider:
             with pytest.raises(ProviderNotConfiguredError, match="Google Generative AI library import failed"):
                 GeminiProvider(api_key="gemini-test-key-123")
 
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("Gemini 1.5 Pro (Google)", "gemini-1.5-pro"),
+            ("Gemini 1.5 Flash", "gemini-1.5-flash"),
+            ("gemini pro", "gemini-1.5-pro"),
+            ("gemini_pro_vision", "gemini-1.0-pro-vision"),
+        ],
+    )
+    def test_gemini_provider_resolves_human_friendly_labels(self, label, expected):
+        """Ensure UI-facing labels map to the correct Gemini model slug."""
+
+        try:
+            import google.generativeai  # type: ignore
+            with patch('google.generativeai.configure'):
+                provider = GeminiProvider(api_key="gemini-test-key-456")
+        except ImportError:
+            pytest.skip("google-generativeai is not installed")
+
+        assert provider._resolve_model_name(label) == expected
+
 
 class TestDeepSeekProvider:
     """Test DeepSeek provider initialization and configuration."""


### PR DESCRIPTION
## Summary
- normalise Gemini model identifiers so human-friendly labels resolve to the API slugs
- add coverage ensuring the provider maps UI-facing Gemini names to canonical models

## Testing
- pytest tests/test_provider_connectivity.py::TestGeminiProvider::test_gemini_provider_initializes_with_api_key -q
- pytest tests/test_provider_connectivity.py::TestGeminiProvider::test_gemini_provider_resolves_human_friendly_labels -q

------
https://chatgpt.com/codex/tasks/task_e_69058c20ffcc832b8eb2b00130abac44