### PR TITLE
Fix Cloud Build image tag substitution

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,18 +15,26 @@ steps:
   # 1) Build the Docker image
   - id: "Build image"
     name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - build
-      - -t
-      - gcr.io/$PROJECT_ID/llmhive-orchestrator:$COMMIT_SHA
-      - .
+      - -c
+      - |
+        set -euo pipefail
+        IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
+        echo "Building ${IMAGE} ..."
+        docker build -t "${IMAGE}" .
 
   # 2) Push the image
   - id: "Push image"
     name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - push
-      - gcr.io/$PROJECT_ID/llmhive-orchestrator:$COMMIT_SHA
+      - -c
+      - |
+        set -euo pipefail
+        IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
+        echo "Pushing ${IMAGE} ..."
+        docker push "${IMAGE}"
 
   # 3) Deploy to Cloud Run with CORRECT secret IDs (kebab-case)
   - id: "Deploy to Cloud Run"
@@ -36,8 +44,8 @@ steps:
       - -c
       - |
         set -euo pipefail
-        IMAGE="gcr.io/$PROJECT_ID/llmhive-orchestrator:$COMMIT_SHA"
-        echo "Deploying $IMAGE to Cloud Run service ${_SERVICE_NAME} in region ${_REGION} ..."
+        IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
+        echo "Deploying ${IMAGE} to Cloud Run service ${_SERVICE_NAME} in region ${_REGION} ..."
         gcloud run deploy "${_SERVICE_NAME}" \
           --image "${IMAGE}" \
           --region "${_REGION}" \


### PR DESCRIPTION
## Summary
- ensure the Cloud Build docker build and push steps compute the image tag inside bash so PROJECT_ID and COMMIT_SHA expand correctly
- reuse the computed image variable when deploying to Cloud Run to keep logging consistent

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_6906f76b9b28832b83136a1078448f68