### PR TITLE
Escape IMAGE references in Cloud Build scripts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,8 +21,8 @@ steps:
       - |
         set -euo pipefail
         IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
-        echo "Building ${IMAGE} ..."
-        docker build -t "${IMAGE}" .
+        echo "Building $${IMAGE} ..."
+        docker build -t "$${IMAGE}" .
 
   # 2) Push the image
   - id: "Push image"
@@ -33,8 +33,8 @@ steps:
       - |
         set -euo pipefail
         IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
-        echo "Pushing ${IMAGE} ..."
-        docker push "${IMAGE}"
+        echo "Pushing $${IMAGE} ..."
+        docker push "$${IMAGE}"
 
   # 3) Deploy to Cloud Run with CORRECT secret IDs (kebab-case)
   - id: "Deploy to Cloud Run"
@@ -45,9 +45,9 @@ steps:
       - |
         set -euo pipefail
         IMAGE="gcr.io/${PROJECT_ID}/llmhive-orchestrator:${COMMIT_SHA}"
-        echo "Deploying ${IMAGE} to Cloud Run service ${_SERVICE_NAME} in region ${_REGION} ..."
+        echo "Deploying $${IMAGE} to Cloud Run service ${_SERVICE_NAME} in region ${_REGION} ..."
         gcloud run deploy "${_SERVICE_NAME}" \
-          --image "${IMAGE}" \
+          --image "$${IMAGE}" \
           --region "${_REGION}" \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
## Summary
- escape IMAGE shell variable references so Cloud Build does not treat them as substitutions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906f9f74eb0832ba6b8310aefdef03c