### PR TITLE
refactor: deliver light theme redesign for cockpit

### DIFF
--- a/ui/app/components/AppShell.tsx
+++ b/ui/app/components/AppShell.tsx
@@ -11,15 +11,9 @@ const navItems = [
   { label: "Providers", href: "#", icon: "🔌" },
 ];
 
-const quickActions = [
-  "New Orchestration",
-  "Import Dataset",
-  "Connect Provider",
-];
-
 type AppShellProps = {
   children: React.ReactNode;
-  rightPanel: React.ReactNode;
+  rightPanel?: React.ReactNode;
   rightPanelCollapsed?: React.ReactNode;
   authSlot?: React.ReactNode;
   displayName?: string | null;
@@ -32,21 +26,22 @@ export default function AppShell({
   authSlot,
   displayName,
 }: AppShellProps) {
-  const [navExpanded, setNavExpanded] = useState(true);
-  const [rightExpanded, setRightExpanded] = useState(true);
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [rightPanelOpen, setRightPanelOpen] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
       const width = window.innerWidth;
-      if (width < 1024) {
-        setRightExpanded(false);
+      setIsDesktop(width >= 1024);
+      if (width <= 1024) {
+        setRightPanelOpen(false);
       }
-      if (width < 768) {
-        setNavExpanded(false);
+      if (width <= 768) {
+        setSidebarExpanded(false);
       } else {
-        setNavExpanded(true);
+        setSidebarExpanded(true);
       }
     };
 
@@ -55,153 +50,122 @@ export default function AppShell({
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        setCommandPaletteOpen((open) => !open);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
-
-  const navWidth = navExpanded ? 280 : 80;
+  const sidebarWidth = sidebarExpanded ? 280 : 80;
+  const rightRailWidth = isDesktop ? (rightPanelOpen ? 360 : 80) : 0;
+  const templateColumns = isDesktop
+    ? `${sidebarWidth}px 1fr ${rightRailWidth}px`
+    : `${sidebarWidth}px 1fr`;
 
   return (
-    <div className="flex min-h-screen w-full flex-col bg-bg text-text">
-      <header className="flex items-center justify-between border-b border-border/70 bg-panel/80 px-4 py-3 shadow-app1 md:hidden">
+    <div className="h-screen bg-bg text-text">
+      <header className="flex items-center justify-between border-b border-border bg-panel px-4 py-3 shadow-sm md:hidden">
         <button
-          className="focus-ring rounded-lg border border-border/80 bg-panel px-3 py-2 text-sm"
-          onClick={() => setMobileNavOpen(true)}
+          type="button"
+          className="focus-ring rounded-card border border-border bg-panelAlt px-3 py-2 text-lg"
+          onClick={() => setMobileSidebarOpen(true)}
           aria-label="Open navigation"
         >
           ☰
         </button>
-        <Link href="#" className="flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-3">
           <Image
-            src="/llmhive-logo.svg"
+            src="/llmhive-logo-light.svg"
             alt="LLMHive"
             width={36}
             height={36}
             className="h-9 w-auto"
             priority
           />
-          <span className="text-sm font-semibold tracking-wide">LLMHive</span>
+          <span className="text-base font-semibold">LLMHive</span>
         </Link>
-        <div className="text-xs text-textdim">{displayName ?? "Guest"}</div>
+        <button
+          type="button"
+          className="focus-ring rounded-card border border-border bg-panelAlt px-3 py-2 text-sm text-textDim"
+          onClick={() => setRightPanelOpen((open) => !open)}
+        >
+          {rightPanelOpen ? "Hide" : "Agents"}
+        </button>
       </header>
 
-      <div className="relative flex flex-1 overflow-hidden">
-        <aside
-          className="relative hidden h-full flex-col border-r border-border/60 bg-panel/80 pb-6 shadow-app1 transition-all duration-app2 ease-[var(--ease)] md:flex"
-          style={{ width: `${navWidth}px` }}
-        >
-          <div className="flex h-14 items-center gap-3 border-b border-border/60 px-3">
-            <Link href="#" className="flex items-center gap-3 focus-ring">
+      <div
+        className="hidden h-full md:grid"
+        style={{ gridTemplateColumns: templateColumns }}
+      >
+        <aside className="flex h-full flex-col border-r border-border bg-panel transition-all duration-200 ease-soft">
+          <div className="flex h-16 items-center gap-3 border-b border-border px-4">
+            <Link href="/" className="flex items-center gap-3">
               <Image
-                src="/llmhive-logo.svg"
+                src="/llmhive-logo-light.svg"
                 alt="LLMHive"
-                width={navExpanded ? 40 : 32}
-                height={navExpanded ? 40 : 32}
-                className={navExpanded ? "h-10 w-auto" : "h-8 w-auto mx-auto"}
+                width={sidebarExpanded ? 40 : 32}
+                height={sidebarExpanded ? 40 : 32}
+                className={sidebarExpanded ? "h-10 w-auto" : "mx-auto h-8 w-auto"}
                 priority
               />
-              {navExpanded && (
-                <span className="text-sm font-semibold tracking-wide">LLMHive</span>
+              {sidebarExpanded && (
+                <span className="text-lg font-semibold">LLMHive</span>
               )}
             </Link>
           </div>
-
-          <nav className="flex-1 space-y-2 px-3 py-4">
+          <nav className="flex-1 space-y-1 px-3 py-4">
             {navItems.map((item) => (
               <Link
                 key={item.label}
                 href={item.href}
-                className="glass flex items-center gap-3 rounded-xl px-3 py-2 text-sm text-text transition duration-app1 ease-[var(--ease)] hover:bg-panel2/80"
+                className="flex items-center gap-3 rounded-card px-3 py-2 text-sm text-text transition-colors duration-150 ease-soft hover:bg-panelAlt"
               >
                 <span aria-hidden className="text-lg">
                   {item.icon}
                 </span>
-                {navExpanded && <span>{item.label}</span>}
+                {sidebarExpanded && <span>{item.label}</span>}
               </Link>
             ))}
           </nav>
-
-          <div className="mt-auto space-y-3 px-3">
-            <div className="rounded-xl border border-border/80 bg-panel/80 px-3 py-2 text-xs text-textdim">
+          <div className="mt-auto space-y-3 px-3 pb-4">
+            <div className="rounded-card border border-border bg-panelAlt px-3 py-2 text-xs text-textDim">
               {displayName ? `Workspace • ${displayName}` : "Workspace • Guest"}
             </div>
             <button
-              onClick={() => setNavExpanded((open) => !open)}
-              className="focus-ring glass flex w-full items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-text"
+              type="button"
+              onClick={() => setSidebarExpanded((expanded) => !expanded)}
+              className="focus-ring flex w-full items-center justify-center gap-2 rounded-card border border-border bg-panelAlt px-3 py-2 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white"
             >
-              {navExpanded ? "Collapse" : "Expand"}
+              {sidebarExpanded ? "Collapse" : "Expand"}
             </button>
+            {authSlot}
           </div>
         </aside>
 
-        <main className="flex-1 overflow-y-auto bg-bg">
+        <main className="overflow-y-auto bg-bg">
           <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-8 lg:px-10">
-            <section className="glass rounded-2xl border border-border/80 bg-panel/80 p-6 shadow-app1">
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                <div>
-                  <h1 className="text-3xl font-semibold text-text">
-                    Multi-LLM Orchestration HQ
-                  </h1>
-                  <p className="mt-2 text-sm text-textdim">
-                    Command, monitor, and refine every agent in your hive from a single glass-metal cockpit.
-                  </p>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {quickActions.map((action) => (
-                      <button
-                        key={action}
-                        className="focus-ring rounded-full border border-border/70 bg-panel px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
-                        type="button"
-                      >
-                        {action}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <div className="flex flex-col items-start gap-3 text-sm text-textdim lg:items-end">
-                  <span className="rounded-xl border border-border/60 bg-panel/70 px-3 py-2">
-                    Status: <span className="font-semibold text-success">Online</span>
-                  </span>
-                  {authSlot}
-                </div>
-              </div>
-            </section>
             {children}
           </div>
         </main>
 
-        <aside
-          className={`hidden h-full border-l border-border/60 bg-panel/80 shadow-app1 transition-all duration-app2 ease-[var(--ease)] lg:flex ${rightExpanded ? "w-[360px]" : "w-[84px]"}`}
-        >
-          {rightExpanded ? (
+        <aside className="hidden h-full border-l border-border bg-panel transition-all duration-200 ease-soft lg:flex" style={{ width: rightRailWidth }}>
+          {rightPanelOpen ? (
             <div className="flex w-full flex-1 flex-col">
-              <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
-                <span className="text-sm font-semibold uppercase tracking-[0.28em] text-textdim">
-                  Agents • Run
-                </span>
+              <div className="flex items-center justify-between border-b border-border px-4 py-4">
+                <span className="text-sm font-semibold text-text">Run • Agents</span>
                 <button
-                  className="focus-ring rounded-lg border border-border/70 bg-panel px-3 py-1 text-xs"
-                  onClick={() => setRightExpanded(false)}
-                  aria-label="Collapse utilities"
+                  type="button"
+                  className="focus-ring rounded-card border border-border bg-panelAlt px-3 py-1 text-xs text-textDim"
+                  onClick={() => setRightPanelOpen(false)}
                 >
-                  Hide
+                  Collapse
                 </button>
               </div>
-              <div className="flex-1 overflow-y-auto p-4 scrollbar-thin">{rightPanel}</div>
+              <div className="flex-1 overflow-y-auto p-4 scrollbar-thin">
+                {rightPanel}
+              </div>
             </div>
           ) : (
             <div className="flex h-full w-full flex-col items-center gap-4 px-3 py-6">
               <button
-                className="focus-ring glass flex h-12 w-12 items-center justify-center rounded-2xl text-lg text-text"
-                onClick={() => setRightExpanded(true)}
-                aria-label="Expand utilities"
+                type="button"
+                className="focus-ring glass flex h-12 w-12 items-center justify-center rounded-card text-lg"
+                onClick={() => setRightPanelOpen(true)}
+                aria-label="Expand agents panel"
               >
                 ☰
               </button>
@@ -211,21 +175,32 @@ export default function AppShell({
         </aside>
       </div>
 
+      <main className="flex flex-1 overflow-y-auto md:hidden">
+        <div className="mx-auto flex w-full max-w-[800px] flex-col gap-6 px-5 py-6">
+          {children}
+        </div>
+      </main>
+
       <button
-        className="fixed bottom-6 right-6 z-30 rounded-full border border-border/70 bg-panel/90 px-3 py-2 text-xs uppercase tracking-[0.3em] text-textdim shadow-app1 backdrop-blur-sm lg:hidden"
-        onClick={() => setRightExpanded((open) => !open)}
+        type="button"
+        className="fixed bottom-6 right-6 z-30 rounded-card border border-border bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition duration-150 ease-soft hover:bg-primaryLight md:hidden"
+        onClick={() => setRightPanelOpen((open) => !open)}
       >
-        {rightExpanded ? "Hide Panel" : "Show Panel"}
+        {rightPanelOpen ? "Close Agents" : "Run • Agents"}
       </button>
 
-      {mobileNavOpen && (
-        <div className="fixed inset-0 z-40 bg-black/70 md:hidden">
-          <aside className="absolute left-0 top-0 flex h-full w-64 flex-col gap-3 border-r border-border/60 bg-panel/95 p-4">
+      {mobileSidebarOpen && (
+        <div className="fixed inset-0 z-40 bg-black/40 md:hidden">
+          <aside className="absolute left-0 top-0 flex h-full w-[280px] flex-col gap-4 border-r border-border bg-panel p-4 shadow-lg">
             <div className="flex items-center justify-between">
-              <Image src="/llmhive-logo.svg" alt="LLMHive" width={36} height={36} className="h-9 w-auto" />
+              <Link href="/" className="flex items-center gap-3">
+                <Image src="/llmhive-logo-light.svg" alt="LLMHive" width={32} height={32} className="h-8 w-auto" />
+                <span className="text-base font-semibold">LLMHive</span>
+              </Link>
               <button
-                className="focus-ring rounded-lg border border-border/70 px-2 py-1 text-sm"
-                onClick={() => setMobileNavOpen(false)}
+                type="button"
+                className="focus-ring rounded-card border border-border bg-panelAlt px-2 py-1 text-sm"
+                onClick={() => setMobileSidebarOpen(false)}
                 aria-label="Close navigation"
               >
                 ✕
@@ -236,40 +211,35 @@ export default function AppShell({
                 <Link
                   key={item.label}
                   href={item.href}
-                  className="glass flex items-center gap-3 rounded-xl px-3 py-2 text-sm text-text"
+                  className="flex items-center gap-3 rounded-card px-3 py-2 text-sm text-text transition-colors duration-150 ease-soft hover:bg-panelAlt"
                 >
                   <span aria-hidden>{item.icon}</span>
                   <span>{item.label}</span>
                 </Link>
               ))}
             </nav>
-            <div className="rounded-xl border border-border/70 bg-panel/80 px-3 py-2 text-xs text-textdim">
+            <div className="rounded-card border border-border bg-panelAlt px-3 py-2 text-xs text-textDim">
               {displayName ? `Workspace • ${displayName}` : "Workspace • Guest"}
             </div>
           </aside>
         </div>
       )}
 
-      {commandPaletteOpen && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-        >
-          <div className="glass w-full max-w-xl rounded-2xl border border-border/80 bg-panel/95 p-6 shadow-app2">
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-text">Command Palette</h2>
+      {rightPanelOpen && rightPanel && (
+        <div className="fixed inset-0 z-40 flex items-end bg-black/30 px-4 pb-8 md:hidden" role="dialog" aria-modal="true">
+          <aside className="glass w-full max-w-md rounded-card border border-border bg-panel p-5 shadow-lg">
+            <div className="mb-4 flex items-center justify-between">
+              <span className="text-base font-semibold text-text">Run • Agents</span>
               <button
-                className="focus-ring rounded-lg border border-border/70 px-2 py-1 text-sm"
-                onClick={() => setCommandPaletteOpen(false)}
+                type="button"
+                className="focus-ring rounded-card border border-border bg-panelAlt px-3 py-1 text-xs text-textDim"
+                onClick={() => setRightPanelOpen(false)}
               >
                 Close
               </button>
             </div>
-            <p className="mt-3 text-sm text-textdim">
-              Quick actions coming soon. Press Esc to exit.
-            </p>
-          </div>
+            <div className="max-h-[60vh] overflow-y-auto pr-1 scrollbar-thin">{rightPanel}</div>
+          </aside>
         </div>
       )}
     </div>

--- a/ui/app/components/ChatSurface.tsx
+++ b/ui/app/components/ChatSurface.tsx
@@ -58,17 +58,17 @@ export default function ChatSurface({ initialMessages }: ChatSurfaceProps) {
 
   return (
     <section className="flex flex-col gap-6">
-      <div className="glass rounded-2xl border border-border/80 bg-panel/80 p-6 shadow-app1">
-        <h2 className="text-xl font-semibold text-text">Welcome to LLMHive</h2>
-        <p className="mt-2 text-sm text-textdim">
+      <div className="glass rounded-card border border-border bg-white p-8 text-center shadow-sm">
+        <h2 className="text-3xl font-semibold text-text">Welcome to LLMHive</h2>
+        <p className="mt-2 text-base text-textDim">
           Orchestrate multiple LLMs toward a single goal. Spin up a mission or load a template to get started.
         </p>
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
           {focusQuickActions.map((chip) => (
             <button
               key={chip}
               type="button"
-              className="focus-ring rounded-full border border-border/70 bg-panel px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+              className="focus-ring rounded-button border border-border bg-panel px-4 py-2 text-xs font-semibold uppercase tracking-wide text-textDim transition-colors duration-150 ease-soft hover:bg-white"
             >
               {chip}
             </button>
@@ -84,41 +84,41 @@ export default function ChatSurface({ initialMessages }: ChatSurfaceProps) {
 
       <form
         onSubmit={handleSubmit}
-        className="sticky bottom-0 mt-auto border-t border-border/80 bg-gradient-to-t from-bg via-bg/90 to-transparent pt-4"
+        className="sticky bottom-0 mt-auto border-t border-transparent bg-gradient-to-t from-bg via-bg/90 to-transparent pt-4"
       >
-        <div className="glass flex flex-col gap-3 rounded-2xl border border-border/80 bg-panel/80 p-3 shadow-app2">
+        <div className="glass flex flex-col gap-3 rounded-card border border-border bg-white p-4 shadow-lg">
           <div className="flex items-center justify-between px-2">
-            <span className="text-xs uppercase tracking-[0.28em] text-textdim">
+            <span className="text-xs font-semibold uppercase tracking-wide text-textDim">
               Composer
             </span>
-            <span className="text-xs text-textdim">Ctrl / Cmd + Enter to run</span>
+            <span className="text-xs text-textDim">Ctrl / Cmd + Enter to run</span>
           </div>
           <textarea
             ref={textareaRef}
-            className="focus-ring scrollbar-thin max-h-48 w-full resize-none rounded-xl border border-border/70 bg-panel px-4 py-3 text-sm leading-relaxed text-text placeholder:text-textdim/60"
+            className="focus-ring scrollbar-thin max-h-48 w-full resize-none rounded-card border border-border bg-panel px-4 py-3 text-sm leading-relaxed text-text placeholder:text-textDim/70"
             rows={1}
             value={input}
             onChange={(event) => setInput(event.target.value)}
             placeholder="Describe the mission for your hive..."
           />
-          <div className="flex items-center justify-between gap-4 px-2">
+          <div className="flex flex-wrap items-center justify-between gap-3 px-2">
             <div className="flex gap-2">
               <button
                 type="button"
-                className="focus-ring rounded-lg border border-border/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+                className="focus-ring rounded-button border border-border bg-panel px-3 py-2 text-xs font-semibold uppercase tracking-wide text-textDim transition-colors duration-150 ease-soft hover:bg-white"
               >
                 Attach
               </button>
               <button
                 type="button"
-                className="focus-ring rounded-lg border border-border/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+                className="focus-ring rounded-button border border-border bg-panel px-3 py-2 text-xs font-semibold uppercase tracking-wide text-textDim transition-colors duration-150 ease-soft hover:bg-white"
               >
                 Settings
               </button>
             </div>
             <button
               type="submit"
-              className="focus-ring inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-black transition duration-app1 ease-[var(--ease)] hover:bg-primary2"
+              className="focus-ring inline-flex items-center gap-2 rounded-button bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors duration-150 ease-soft hover:bg-primaryLight"
             >
               Run
             </button>
@@ -130,16 +130,17 @@ export default function ChatSurface({ initialMessages }: ChatSurfaceProps) {
 }
 
 function ChatBubble({ message }: { message: ChatMessage }) {
-  const alignment = message.role === "user" ? "items-end" : "items-start";
+  const alignment = message.role === "user" ? "justify-end" : "justify-start";
   const label = message.role === "assistant" ? "LLMHive" : "You";
-  const accent = message.role === "assistant" ? "border-primary/60" : "border-border/80";
+  const accentBorder =
+    message.role === "assistant" ? "border-primary" : "border-border";
 
   return (
     <div className={`flex ${alignment}`}>
       <div
-        className={`glass w-full max-w-2xl rounded-2xl border ${accent} bg-panel/80 p-4 text-sm leading-relaxed text-text shadow-app1`}
+        className={`glass max-w-[75%] rounded-card border ${accentBorder} bg-white px-5 py-4 text-sm leading-relaxed text-text shadow-sm`}
       >
-        <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.28em] text-textdim">
+        <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wide text-textDim">
           <span>{label}</span>
           <span>{message.role}</span>
         </div>

--- a/ui/app/components/PromptForm.tsx
+++ b/ui/app/components/PromptForm.tsx
@@ -259,48 +259,48 @@ export default function PromptForm({ userId }: PromptFormProps) {
 
   return (
     <section className="space-y-6">
-      <header className="glass rounded-2xl border border-border/60 bg-panel/80 p-6 shadow-app1">
+      <header className="glass rounded-2xl border border-border bg-white p-6 shadow-sm">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.32em] text-textdim">Commander</p>
+            <p className="text-xs uppercase tracking-[0.32em] text-textDim">Commander</p>
             <h2 className="text-2xl font-semibold text-text">Orchestration Console</h2>
-            <p className="max-w-2xl text-sm text-textdim">
+            <p className="max-w-2xl text-sm text-textDim">
               Select the models and reasoning strategies to deploy for this mission. LLMHive will route insight across the hive and return a fused response.
             </p>
           </div>
           <div className="flex gap-2">
-            <div className="rounded-full border border-border px-3 py-1 text-xs uppercase tracking-widest text-textdim">Ctrl / Cmd + Enter to run</div>
+            <div className="rounded-full border border-border px-3 py-1 text-xs uppercase tracking-widest text-textDim">Ctrl / Cmd + Enter to run</div>
           </div>
         </div>
       </header>
 
       <form
-        className="glass rounded-2xl border border-border/80 bg-panel/80 p-6 shadow-app2"
+        className="glass rounded-2xl border border-border bg-white p-6 shadow-lg"
         onSubmit={handleSubmit}
       >
         <div className="grid gap-6 lg:grid-cols-2">
           <fieldset className="flex flex-col gap-4">
-            <legend className="text-xs font-semibold uppercase tracking-[0.28em] text-textdim">
+            <legend className="text-xs font-semibold uppercase tracking-[0.28em] text-textDim">
               Model Collective
             </legend>
             <div className="relative">
               <button
                 type="button"
-                className="focus-ring flex w-full items-center justify-between rounded-xl border border-border bg-panel px-4 py-3 text-left text-sm font-medium text-text shadow-inner transition duration-app1 ease-[var(--ease)] hover:border-primary/70"
+                className="focus-ring flex w-full items-center justify-between rounded-xl border border-border bg-panel px-4 py-3 text-left text-sm font-medium text-text shadow-inner transition duration-150 ease-soft hover:border-primary/70"
                 onClick={() => setModelMenuOpen((open) => !open)}
                 aria-expanded={isModelMenuOpen}
               >
                 <span>
                   {selectedModels.length} selected
                 </span>
-                <span className="text-textdim">▼</span>
+                <span className="text-textDim">▼</span>
               </button>
               {isModelMenuOpen && (
-                <div className="scrollbar-thin absolute z-30 mt-3 w-full max-h-80 overflow-y-auto rounded-2xl border border-border/80 bg-panel2 p-3 shadow-app2">
+                <div className="scrollbar-thin absolute z-30 mt-3 w-full max-h-80 overflow-y-auto rounded-2xl border border-border bg-panelAlt p-3 shadow-lg">
                   {MODEL_OPTIONS.map((model) => (
                     <label
                       key={model.value}
-                      className="flex cursor-pointer gap-3 rounded-xl p-3 transition duration-app1 ease-[var(--ease)] hover:bg-primary/10"
+                      className="flex cursor-pointer gap-3 rounded-xl p-3 transition duration-150 ease-soft hover:bg-primary/10"
                     >
                       <input
                         type="checkbox"
@@ -310,11 +310,11 @@ export default function PromptForm({ userId }: PromptFormProps) {
                       />
                       <span>
                         <span className="block text-sm font-semibold text-text">{model.label}</span>
-                        <span className="mt-1 block text-xs text-textdim">{model.description}</span>
+                        <span className="mt-1 block text-xs text-textDim">{model.description}</span>
                       </span>
                     </label>
                   ))}
-                  <p className="mt-4 border-t border-border/60 pt-3 text-xs text-textdim">
+                  <p className="mt-4 border-t border-border pt-3 text-xs text-textDim">
                     At least one model must remain active to deploy the hive.
                   </p>
                 </div>
@@ -327,7 +327,7 @@ export default function PromptForm({ userId }: PromptFormProps) {
                 return (
                   <span
                     key={modelId}
-                    className="rounded-full border border-border/80 bg-panel px-3 py-1 text-xs text-text"
+                    className="rounded-full border border-border bg-panel px-3 py-1 text-xs text-text"
                   >
                     {model.label}
                   </span>
@@ -337,27 +337,27 @@ export default function PromptForm({ userId }: PromptFormProps) {
           </fieldset>
 
           <fieldset className="flex flex-col gap-4">
-            <legend className="text-xs font-semibold uppercase tracking-[0.28em] text-textdim">
+            <legend className="text-xs font-semibold uppercase tracking-[0.28em] text-textDim">
               Reasoning Strategy
             </legend>
             <div className="relative">
               <button
                 type="button"
-                className="focus-ring flex w-full items-center justify-between rounded-xl border border-border bg-panel px-4 py-3 text-left text-sm font-medium text-text shadow-inner transition duration-app1 ease-[var(--ease)] hover:border-primary/70"
+                className="focus-ring flex w-full items-center justify-between rounded-xl border border-border bg-panel px-4 py-3 text-left text-sm font-medium text-text shadow-inner transition duration-150 ease-soft hover:border-primary/70"
                 onClick={() => setStrategyMenuOpen((open) => !open)}
                 aria-expanded={isStrategyMenuOpen}
               >
                 <span>
                   {selectedStrategies.length} active
                 </span>
-                <span className="text-textdim">▼</span>
+                <span className="text-textDim">▼</span>
               </button>
               {isStrategyMenuOpen && (
-                <div className="scrollbar-thin absolute z-30 mt-3 w-full max-h-80 overflow-y-auto rounded-2xl border border-border/80 bg-panel2 p-3 shadow-app2">
+                <div className="scrollbar-thin absolute z-30 mt-3 w-full max-h-80 overflow-y-auto rounded-2xl border border-border bg-panelAlt p-3 shadow-lg">
                   {STRATEGY_OPTIONS.map((strategy) => (
                     <label
                       key={strategy.value}
-                      className="flex cursor-pointer gap-3 rounded-xl p-3 transition duration-app1 ease-[var(--ease)] hover:bg-primary/10"
+                      className="flex cursor-pointer gap-3 rounded-xl p-3 transition duration-150 ease-soft hover:bg-primary/10"
                     >
                       <input
                         type="checkbox"
@@ -367,43 +367,43 @@ export default function PromptForm({ userId }: PromptFormProps) {
                       />
                       <span>
                         <span className="block text-sm font-semibold text-text">{strategy.label}</span>
-                        <span className="mt-1 block text-xs text-textdim">{strategy.description}</span>
+                        <span className="mt-1 block text-xs text-textDim">{strategy.description}</span>
                       </span>
                     </label>
                   ))}
-                  <p className="mt-4 border-t border-border/60 pt-3 text-xs text-textdim">
+                  <p className="mt-4 border-t border-border pt-3 text-xs text-textDim">
                     Selecting Auto Orchestration deselects other strategies.
                   </p>
                 </div>
               )}
             </div>
-            <p className="text-sm text-textdim">{orchestratorSummary.strategyDescription}</p>
+            <p className="text-sm text-textDim">{orchestratorSummary.strategyDescription}</p>
           </fieldset>
         </div>
 
         <div className="mt-8 space-y-4">
           <label className="flex flex-col gap-2 text-sm text-text">
-            <span className="text-xs font-semibold uppercase tracking-[0.28em] text-textdim">Mission Brief</span>
+            <span className="text-xs font-semibold uppercase tracking-[0.28em] text-textDim">Mission Brief</span>
             <textarea
               ref={textareaRef}
-              className="focus-ring scrollbar-thin min-h-[220px] w-full resize-y rounded-2xl border border-border bg-panel px-4 py-4 text-sm leading-relaxed text-text placeholder:text-textdim/60"
+              className="focus-ring scrollbar-thin min-h-[220px] w-full resize-y rounded-2xl border border-border bg-panel px-4 py-4 text-sm leading-relaxed text-text placeholder:text-textDim/60"
               placeholder="Describe the outcome you want the hive to pursue..."
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
             />
           </label>
-          <div className="grid gap-4 rounded-2xl border border-border/80 bg-panel/70 p-4 sm:grid-cols-2">
+          <div className="grid gap-4 rounded-2xl border border-border bg-panel p-4 sm:grid-cols-2">
             <div>
-              <h4 className="text-xs font-semibold uppercase tracking-[0.28em] text-textdim">Ensemble</h4>
-              <ul className="mt-2 space-y-1 text-sm text-textdim">
+              <h4 className="text-xs font-semibold uppercase tracking-[0.28em] text-textDim">Ensemble</h4>
+              <ul className="mt-2 space-y-1 text-sm text-textDim">
                 {orchestratorSummary.selectedModels.map((model) => (
                   <li key={model.value}>{model.label}</li>
                 ))}
               </ul>
             </div>
             <div>
-              <h4 className="text-xs font-semibold uppercase tracking-[0.28em] text-textdim">Strategy</h4>
-              <p className="mt-2 text-sm text-textdim">
+              <h4 className="text-xs font-semibold uppercase tracking-[0.28em] text-textDim">Strategy</h4>
+              <p className="mt-2 text-sm text-textDim">
                 {orchestratorSummary.strategyLabel}
               </p>
             </div>
@@ -411,14 +411,14 @@ export default function PromptForm({ userId }: PromptFormProps) {
         </div>
 
         <div className="mt-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-3 text-sm text-textdim">
+          <div className="flex items-center gap-3 text-sm text-textDim">
             <span className="inline-flex h-3 w-3 rounded-full bg-primary" aria-hidden />
             <span>Hive memory enabled for this run.</span>
           </div>
           <div className="flex flex-wrap gap-3">
             <button
               type="reset"
-              className="focus-ring rounded-xl border border-border px-4 py-2 text-sm font-semibold text-text transition duration-app1 ease-[var(--ease)] hover:border-primary/70"
+              className="focus-ring rounded-button border border-border bg-panel px-4 py-2 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white"
               onClick={() => {
                 setPrompt("");
                 setResult("");
@@ -432,7 +432,7 @@ export default function PromptForm({ userId }: PromptFormProps) {
             <button
               type="submit"
               disabled={isLoading}
-              className="focus-ring inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-black transition duration-app1 ease-[var(--ease)] hover:bg-primary2 disabled:cursor-not-allowed disabled:opacity-70"
+              className="focus-ring inline-flex items-center justify-center gap-2 rounded-button bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors duration-150 ease-soft hover:bg-primaryLight disabled:cursor-not-allowed disabled:opacity-70"
             >
               {isLoading ? "Deploying hive..." : "Run orchestration"}
             </button>
@@ -441,12 +441,12 @@ export default function PromptForm({ userId }: PromptFormProps) {
       </form>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="glass rounded-2xl border border-border/70 bg-panel/80 p-6 shadow-app1">
+        <div className="glass rounded-2xl border border-border bg-white p-6 shadow-sm">
           <h3 className="text-lg font-semibold text-text">Orchestration Output</h3>
-          <p className="mt-2 text-sm text-textdim">
+          <p className="mt-2 text-sm text-textDim">
             Responses are synthesized across the active agents and appear here with trace metadata.
           </p>
-          <div className="scrollbar-thin mt-4 max-h-72 overflow-y-auto rounded-xl border border-border/60 bg-panel/70 p-4 text-sm leading-relaxed text-text">
+          <div className="scrollbar-thin mt-4 max-h-72 overflow-y-auto rounded-xl border border-border bg-panel p-4 text-sm leading-relaxed text-text">
             {error && (
               <p className="text-danger">{error}</p>
             )}
@@ -454,29 +454,29 @@ export default function PromptForm({ userId }: PromptFormProps) {
               <pre className="whitespace-pre-wrap text-text">{result || "Awaiting hive response..."}</pre>
             )}
             {!error && !result && !isLoading && (
-              <p className="text-textdim">
+              <p className="text-textDim">
                 Launch a mission to view the orchestrated answer.
               </p>
             )}
           </div>
         </div>
-        <div className="glass rounded-2xl border border-border/70 bg-panel/80 p-6 shadow-app1">
+        <div className="glass rounded-2xl border border-border bg-white p-6 shadow-sm">
           <h3 className="text-lg font-semibold text-text">Execution Log</h3>
-          <p className="mt-2 text-sm text-textdim">
+          <p className="mt-2 text-sm text-textDim">
             Track which agents engaged, their status, and any follow-up actions required.
           </p>
-          <ul className="mt-4 space-y-3 text-sm text-textdim">
-            <li className="flex items-center justify-between rounded-xl border border-border/60 bg-panel/80 px-4 py-3">
+          <ul className="mt-4 space-y-3 text-sm text-textDim">
+            <li className="flex items-center justify-between rounded-xl border border-border bg-white px-4 py-3">
               <span>Router Agent</span>
               <span className="text-xs font-semibold text-success">Complete</span>
             </li>
-            <li className="flex items-center justify-between rounded-xl border border-border/60 bg-panel/80 px-4 py-3">
+            <li className="flex items-center justify-between rounded-xl border border-border bg-white px-4 py-3">
               <span>Critic Squad</span>
               <span className="text-xs font-semibold text-warning">Reviewing</span>
             </li>
-            <li className="flex items-center justify-between rounded-xl border border-border/60 bg-panel/80 px-4 py-3">
+            <li className="flex items-center justify-between rounded-xl border border-border bg-white px-4 py-3">
               <span>Research Circle</span>
-              <span className="text-xs font-semibold text-textdim">Queued</span>
+              <span className="text-xs font-semibold text-textDim">Queued</span>
             </li>
           </ul>
         </div>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -3,9 +3,11 @@
 @tailwind utilities;
 
 :root {
-  --ease: cubic-bezier(.22,.61,.36,1);
-  --dur-1: 160ms;
-  --dur-2: 260ms;
+  --glass-fill: rgba(255, 255, 255, 0.6);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 4px 20px rgba(0, 0, 0, 0.1);
+  --radius-card: 8px;
+  --radius-button: 16px;
 }
 
 @layer base {
@@ -15,7 +17,7 @@
     height: 100%;
     background-color: theme("colors.bg");
     color: theme("colors.text");
-    font-family: "Inter", "Plus Jakarta Sans", "Roboto Flex", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: theme("fontFamily.sans");
   }
 
   body {
@@ -23,11 +25,11 @@
   }
 
   ::selection {
-    @apply bg-primary text-black;
+    @apply bg-primary text-white;
   }
 
   a {
-    @apply text-primary transition-colors duration-app1 ease-[var(--ease)];
+    @apply text-primary transition-colors duration-150 ease-soft;
   }
 
   button,
@@ -38,14 +40,18 @@
 }
 
 .glass {
-  background: rgba(201, 210, 224, 0.08);
-  border: 1px solid rgba(201, 210, 224, 0.18);
-  backdrop-filter: saturate(130%) blur(10px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  border-radius: 16px;
+  background: var(--glass-fill);
+  border: 1px solid rgba(209, 213, 219, 0.6);
+  backdrop-filter: saturate(130%) blur(6px);
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-card);
 }
 
-.focus-ring:focus-visible {
+.focus-ring:focus-visible,
+button:focus-visible,
+a:focus-visible,
+textarea:focus-visible,
+input:focus-visible {
   outline: 2px solid #ffc74d;
   outline-offset: 2px;
 }
@@ -59,6 +65,6 @@
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: rgba(201, 210, 224, 0.22);
+  background: rgba(209, 213, 219, 0.6);
   border-radius: 999px;
 }

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -15,7 +15,7 @@ function SignInButton() {
     >
       <button
         type="submit"
-        className="focus-ring rounded-xl border border-border/70 bg-panel px-4 py-2 text-sm font-semibold text-text transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+        className="focus-ring rounded-button border border-border bg-panel px-4 py-2 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white"
       >
         Sign in with GitHub
       </button>
@@ -25,8 +25,8 @@ function SignInButton() {
 
 function SignOutButton({ user }: { user: User }) {
   return (
-    <div className="flex flex-col items-start gap-3 text-sm text-textdim">
-      <span className="rounded-xl border border-border/70 bg-panel/70 px-3 py-2">
+    <div className="flex flex-col items-start gap-3 text-sm text-textDim">
+      <span className="rounded-card border border-border bg-panelAlt px-3 py-2">
         Signed in as {user?.name ?? user?.email ?? "Innovator"}
       </span>
       <form
@@ -37,7 +37,7 @@ function SignOutButton({ user }: { user: User }) {
       >
         <button
           type="submit"
-          className="focus-ring rounded-xl border border-border/70 bg-panel px-4 py-2 text-sm font-semibold text-text transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+          className="focus-ring rounded-button border border-border bg-panel px-4 py-2 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white"
         >
           Sign out
         </button>
@@ -72,38 +72,35 @@ function RightPanelContent() {
           <AgentCard key={agent.name} {...agent} />
         ))}
       </div>
-      <div className="glass rounded-2xl border border-border/70 bg-panel/80 p-4 shadow-app1">
+      <div className="glass rounded-card border border-border bg-white p-4 shadow-sm">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-semibold text-text">Orchestration Visualizer</h3>
-          <span className="text-xs uppercase tracking-[0.28em] text-textdim">Beta</span>
+          <span className="text-xs uppercase tracking-wide text-textDim">Beta</span>
         </div>
-        <div
-          id="orc-graph"
-          className="mt-3 h-40 w-full rounded-xl border border-border/60 bg-panel/60"
-        />
-        <p className="mt-3 text-xs text-textdim">
+        <div className="mt-3 h-40 w-full rounded-card border border-border bg-panel" />
+        <p className="mt-3 text-xs text-textDim">
           Visual sequencing of agent hand-offs and synchronization pulses will render here.
         </p>
       </div>
-      <section className="glass rounded-2xl border border-border/70 bg-panel/80 p-4 shadow-app1">
+      <section className="glass rounded-card border border-border bg-white p-4 shadow-sm">
         <header className="flex items-center justify-between">
           <h3 className="text-sm font-semibold text-text">Context</h3>
           <button
             type="button"
-            className="focus-ring rounded-lg border border-border/70 px-3 py-1 text-xs text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+            className="focus-ring rounded-button border border-border bg-panel px-3 py-1 text-xs text-textDim transition-colors duration-150 ease-soft hover:bg-white"
           >
             Add file
           </button>
         </header>
-        <ul className="mt-3 space-y-2 text-xs text-textdim">
+        <ul className="mt-3 space-y-2 text-xs text-textDim">
           <li>• Market research brief.pdf</li>
           <li>• EU compliance checklist.md</li>
           <li>• Persona targets.json</li>
         </ul>
       </section>
-      <section className="glass rounded-2xl border border-border/70 bg-panel/80 p-4 shadow-app1">
+      <section className="glass rounded-card border border-border bg-white p-4 shadow-sm">
         <h3 className="text-sm font-semibold text-text">Run Status</h3>
-        <ul className="mt-3 space-y-2 text-xs text-textdim">
+        <ul className="mt-3 space-y-2 text-xs text-textDim">
           <li className="flex items-center justify-between">
             <span>01 • Ingestion</span>
             <span className="text-success">Complete</span>
@@ -114,7 +111,7 @@ function RightPanelContent() {
           </li>
           <li className="flex items-center justify-between">
             <span>03 • Critique</span>
-            <span className="text-textdim">Pending</span>
+            <span className="text-textDim">Pending</span>
           </li>
         </ul>
       </section>
@@ -130,13 +127,13 @@ function CollapsedUtilities() {
     { label: "Files", icon: "📁" },
   ];
   return (
-    <div className="flex flex-col items-center gap-4 text-xs text-textdim">
+    <div className="flex flex-col items-center gap-4 text-xs text-textDim">
       {items.map((item) => (
         <div key={item.label} className="flex flex-col items-center gap-1">
-          <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 bg-panel/80 text-lg text-text">
+          <span className="flex h-12 w-12 items-center justify-center rounded-card border border-border bg-panel text-lg text-text">
             {item.icon}
           </span>
-          <span className="uppercase tracking-[0.28em]">{item.label}</span>
+          <span className="uppercase tracking-wide">{item.label}</span>
         </div>
       ))}
     </div>
@@ -155,28 +152,32 @@ function AgentCard({
   const statusLabel =
     status === "thinking" ? "Thinking" : status === "queued" ? "Queued" : "Idle";
   const statusColor =
-    status === "thinking" ? "bg-primary" : status === "queued" ? "bg-warning" : "bg-textdim";
+    status === "thinking"
+      ? "bg-primary"
+      : status === "queued"
+      ? "bg-warning"
+      : "bg-textDim";
 
   return (
-    <article className="glass flex flex-col gap-2 rounded-2xl border border-border/70 bg-panel/80 p-4 shadow-app1">
+    <article className="glass flex flex-col gap-2 rounded-card border border-border bg-white p-4 shadow-sm">
       <header className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-border/70 bg-panel/80 text-lg">
+          <span className="flex h-10 w-10 items-center justify-center rounded-card border border-border bg-panel text-lg">
             🤖
           </span>
           <div>
             <h4 className="text-sm font-semibold text-text">{name}</h4>
-            <p className="text-xs text-textdim">{description}</p>
+            <p className="text-xs text-textDim">{description}</p>
           </div>
         </div>
-        <span className={`inline-flex items-center gap-2 text-xs uppercase tracking-[0.28em] text-textdim`}>
+        <span className="inline-flex items-center gap-2 text-xs uppercase tracking-wide text-textDim">
           <span className={`h-2 w-2 rounded-full ${statusColor}`} aria-hidden />
           {statusLabel}
         </span>
       </header>
       <button
         type="button"
-        className="focus-ring self-start rounded-lg border border-border/70 px-3 py-1 text-xs text-textdim transition duration-app1 ease-[var(--ease)] hover:border-primary/60"
+        className="focus-ring self-start rounded-button border border-border bg-panel px-3 py-1 text-xs text-textDim transition-colors duration-150 ease-soft hover:bg-white"
       >
         Optimize Prompt
       </button>
@@ -192,13 +193,39 @@ export default async function Home() {
 
   return (
     <AppShell
-      authSlot={authControls}
       displayName={user?.name ?? user?.email ?? null}
       rightPanel={<RightPanelContent />}
       rightPanelCollapsed={<CollapsedUtilities />}
     >
+      <section className="glass rounded-card border border-border bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-4">
+            <h1 className="text-3xl font-semibold text-text">Multi-LLM Orchestration HQ</h1>
+            <p className="max-w-2xl text-base text-textDim">
+              Command, monitor, and refine every agent in your hive from a bright, enterprise-grade cockpit. Launch orchestrations or revisit conversations with a single click.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <button className="focus-ring rounded-button bg-primary px-5 py-3 text-sm font-semibold text-white transition-colors duration-150 ease-soft hover:bg-primaryLight" type="button">
+                New Orchestration
+              </button>
+              <button className="focus-ring rounded-button border border-border bg-panel px-5 py-3 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white" type="button">
+                Connect Provider
+              </button>
+              <button className="focus-ring rounded-button border border-border bg-panel px-5 py-3 text-sm font-semibold text-text transition-colors duration-150 ease-soft hover:bg-white" type="button">
+                Import Dataset
+              </button>
+            </div>
+          </div>
+          <div className="flex flex-col items-start gap-3 text-sm text-textDim lg:items-end">
+            <span className="rounded-card border border-border bg-panelAlt px-3 py-2">
+              Status: <span className="font-semibold text-success">Online</span>
+            </span>
+            {authControls}
+          </div>
+        </div>
+      </section>
       <ChatSurface />
-      <Suspense fallback={<div className="glass rounded-2xl border border-border/80 bg-panel/80 p-6 text-sm text-textdim">Loading orchestration cockpit…</div>}>
+      <Suspense fallback={<div className="glass rounded-card border border-border bg-white p-6 text-sm text-textDim shadow-sm">Loading orchestration cockpit…</div>}>
         <PromptForm userId={user?.email ?? user?.id ?? "guest"} />
       </Suspense>
     </AppShell>

--- a/ui/public/llmhive-logo-light.svg
+++ b/ui/public/llmhive-logo-light.svg
@@ -1,0 +1,50 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="24" fill="white"/>
+  <g filter="url(#glow)">
+    <circle cx="80" cy="74" r="44" fill="url(#core)"/>
+  </g>
+  <g clip-path="url(#clip0)">
+    <g filter="url(#hexShadow)">
+      <path d="M80 22L94 30.8V48.4L80 57.2L66 48.4V30.8L80 22Z" fill="#FFB31A"/>
+      <path d="M66 48.4L80 57.2V74.8L66 83.6L52 74.8V57.2L66 48.4Z" fill="#FFC74D"/>
+      <path d="M94 48.4L108 57.2V74.8L94 83.6L80 74.8V57.2L94 48.4Z" fill="#FFBD33"/>
+      <path d="M80 74.8L94 83.6V101.2L80 110L66 101.2V83.6L80 74.8Z" fill="#FFD36C"/>
+      <path d="M52 74.8L66 83.6V101.2L52 110L38 101.2V83.6L52 74.8Z" fill="#FFB31A" opacity="0.6"/>
+      <path d="M108 74.8L122 83.6V101.2L108 110L94 101.2V83.6L108 74.8Z" fill="#FFB31A" opacity="0.55"/>
+    </g>
+  </g>
+  <g filter="url(#ringShadow)">
+    <path d="M38 116C56 133 104 142 132 102" stroke="url(#ring)" stroke-width="7" stroke-linecap="round"/>
+  </g>
+  <g filter="url(#ringShadow)">
+    <path d="M30 60C46 36 112 24 136 78" stroke="url(#ring)" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <text x="50%" y="144" fill="#9CA3AF" font-family="Inter, sans-serif" font-size="20" font-weight="600" letter-spacing="6" text-anchor="middle">LLMHIVE</text>
+  <defs>
+    <linearGradient id="core" x1="48" y1="28" x2="120" y2="120" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE08A"/>
+      <stop offset="1" stop-color="#FFB31A"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="32" y1="40" x2="132" y2="120" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E5E7EB"/>
+      <stop offset="0.6" stop-color="#BFC6D4"/>
+      <stop offset="1" stop-color="#FFB31A"/>
+    </linearGradient>
+    <filter id="glow" x="20" y="14" width="120" height="120" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="hexShadow" x="28" y="16" width="104" height="108" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="6" flood-color="#F59E0B" flood-opacity="0.25"/>
+    </filter>
+    <filter id="ringShadow" x="20" y="28" width="120" height="112" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#CBD5F5" flood-opacity="0.45"/>
+    </filter>
+    <clipPath id="clip0">
+      <circle cx="80" cy="74" r="48"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: false,
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: ["class"],
+  darkMode: false,
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -10,33 +10,41 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        bg: "#0b1220",
-        panel: "#0f1a2b",
-        panel2: "#131e33",
-        text: "#e6e9ef",
-        textdim: "#a8b1c4",
+        bg: "#ffffff",
+        panel: "#f7f8fa",
+        panelAlt: "#eceff4",
+        text: "#1f2937",
+        textDim: "#6b7280",
         primary: "#ffb31a",
-        primary2: "#ffc74d",
-        border: "#22324a",
-        glassStroke: "#c9d2e0",
-        success: "#2dd4bf",
-        warning: "#f59e0b",
-        danger: "#ef4444",
+        primaryLight: "#ffc74d",
+        border: "#d1d5db",
+        success: "#1f9d55",
+        warning: "#b7791f",
+        danger: "#dc2626",
       },
       borderRadius: {
+        card: "8px",
+        button: "16px",
         xl: "24px",
-        lg: "16px",
       },
       boxShadow: {
-        app1: "0 2px 8px rgba(0,0,0,.35)",
-        app2: "0 6px 24px rgba(0,0,0,.45)",
+        sm: "0 1px 3px rgba(0,0,0,0.1)",
+        lg: "0 4px 20px rgba(0,0,0,0.1)",
+      },
+      fontFamily: {
+        sans: [
+          "Inter",
+          "Plus Jakarta Sans",
+          "Roboto Flex",
+          "system-ui",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "Segoe UI",
+          "sans-serif",
+        ],
       },
       transitionTimingFunction: {
-        app: "cubic-bezier(.22,.61,.36,1)",
-      },
-      transitionDuration: {
-        app1: "160ms",
-        app2: "260ms",
+        soft: "cubic-bezier(0.22,0.61,0.36,1)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- introduce light-theme design tokens and updated glass styling for the UI system
- rebuild the AppShell with responsive sidebar/right panel behavior and apply refreshed hero layout
- refresh chat and orchestration surfaces to match the new enterprise light look and add the white-background logo asset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690b01126294832b87ea4c68c9e28c8f