### PR TITLE
fix workflow secret fetch for launch verification

### DIFF
--- a/.github/workflows/quality-regression.yml
+++ b/.github/workflows/quality-regression.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Fetch secrets from GCP Secret Manager
         id: fetch-secrets
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           echo "Fetching secrets from GCP Secret Manager..."
           
@@ -248,7 +248,7 @@ jobs:
         continue-on-error: true
 
       - name: Fetch Slack webhook from GCP Secret Manager
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           SLACK_URL=$(gcloud secrets versions access latest --secret="slack-webhook-url" --project=llmhive-orchestrator 2>/dev/null || echo "")
           if [ -n "$SLACK_URL" ]; then

--- a/.github/workflows/quality-regression.yml
+++ b/.github/workflows/quality-regression.yml
@@ -89,6 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: unit-quality-tests
+    permissions:
+      contents: read
+      id-token: write
     
     # Only run if:
     # - Manually triggered with run_live_audit=true, OR
@@ -232,6 +235,9 @@ jobs:
     name: Notify on Failure
     runs-on: ubuntu-latest
     needs: [unit-quality-tests, live-audit]
+    permissions:
+      contents: read
+      id-token: write
     if: |
       failure() && 
       github.event_name == 'schedule' &&

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -22,6 +22,7 @@ on:
         default: 'critical'
         type: choice
         options:
+          - secrets_only
           - critical
           - full
           - domain
@@ -51,6 +52,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
     
     outputs:
       passed: ${{ steps.run-benchmark.outputs.passed }}
@@ -101,6 +106,42 @@ jobs:
             echo "BENCHMARK_MODE=local" >> $GITHUB_ENV
             echo "Using local mode (direct Python invocation)"
           fi
+
+      - name: Authenticate to Google Cloud for benchmark secrets
+        id: gcp-auth-bench
+        if: steps.mode.outputs.target == 'production'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+        continue-on-error: true
+
+      - name: Fetch benchmark API key from GCP Secret Manager
+        if: steps.mode.outputs.target == 'production' && steps['gcp-auth-bench'].outcome == 'success'
+        run: |
+          API_KEY=$(gcloud secrets versions access latest --secret="api-key" --project=llmhive-orchestrator 2>/dev/null || echo "")
+          if [ -n "${API_KEY:-}" ]; then
+            echo "::add-mask::$API_KEY"
+            echo "LLMHIVE_API_KEY=$API_KEY" >> $GITHUB_ENV
+            echo "✅ Retrieved api-key from Secret Manager for production benchmark run"
+          else
+            echo "::warning::api-key not found in Secret Manager"
+          fi
+
+      - name: Verify production secret wiring only
+        if: steps.mode.outputs.mode == 'secrets_only'
+        run: |
+          echo "Running secrets-only verification in $BENCHMARK_MODE mode"
+          if [ "${{ steps.mode.outputs.target }}" == "production" ]; then
+            if [ -z "${LLMHIVE_API_KEY:-}" ]; then
+              echo "::error::Secrets-only production verification requires LLMHIVE_API_KEY from Secret Manager"
+              exit 1
+            fi
+            echo "✅ Production benchmark API key was fetched successfully"
+          else
+            echo "✅ Local target selected; no production secret fetch required"
+          fi
+          echo "No benchmark suite executed in secrets_only mode."
       
       - name: Run Critical Benchmarks
         if: steps.mode.outputs.mode == 'critical'
@@ -109,6 +150,10 @@ jobs:
           echo "Running benchmarks in $BENCHMARK_MODE mode"
           if [ "$BENCHMARK_MODE" == "http" ]; then
             echo "  Target URL: $LLMHIVE_BENCHMARK_URL"
+            if [ -z "${LLMHIVE_API_KEY:-}" ]; then
+              echo "::error::Production HTTP benchmark mode requires LLMHIVE_API_KEY or API_KEY"
+              exit 1
+            fi
           fi
           python -m llmhive.app.benchmarks.cli \
             --systems llmhive \
@@ -123,6 +168,10 @@ jobs:
           echo "Running benchmarks in $BENCHMARK_MODE mode"
           if [ "$BENCHMARK_MODE" == "http" ]; then
             echo "  Target URL: $LLMHIVE_BENCHMARK_URL"
+            if [ -z "${LLMHIVE_API_KEY:-}" ]; then
+              echo "::error::Production HTTP benchmark mode requires LLMHIVE_API_KEY or API_KEY"
+              exit 1
+            fi
           fi
           python -m llmhive.app.benchmarks.cli \
             --systems llmhive \
@@ -136,6 +185,10 @@ jobs:
           echo "Running benchmarks in $BENCHMARK_MODE mode"
           if [ "$BENCHMARK_MODE" == "http" ]; then
             echo "  Target URL: $LLMHIVE_BENCHMARK_URL"
+            if [ -z "${LLMHIVE_API_KEY:-}" ]; then
+              echo "::error::Production HTTP benchmark mode requires LLMHIVE_API_KEY or API_KEY"
+              exit 1
+            fi
           fi
           python -m llmhive.app.benchmarks.cli \
             --suite benchmarks/suites/domain_specific_v1.yaml \
@@ -154,7 +207,7 @@ jobs:
         continue-on-error: true
 
       - name: Fetch API keys from GCP Secret Manager
-        if: inputs.enable_external && steps.gcp-auth.outcome == 'success'
+        if: inputs.enable_external && steps['gcp-auth'].outcome == 'success'
         run: |
           echo "Fetching API keys from GCP Secret Manager..."
           
@@ -321,6 +374,9 @@ jobs:
     needs: benchmark
     runs-on: ubuntu-latest
     if: needs.benchmark.outputs.passed == 'false'
+    permissions:
+      contents: read
+      id-token: write
     
     steps:
       # Authenticate to GCP for Secret Manager access
@@ -334,7 +390,7 @@ jobs:
 
       - name: Fetch Slack webhook from GCP Secret Manager
         id: fetch-slack
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           SLACK_URL=$(gcloud secrets versions access latest --secret="slack-webhook-url" --project=llmhive-orchestrator 2>/dev/null || echo "")
           if [ -n "$SLACK_URL" ]; then
@@ -345,7 +401,7 @@ jobs:
           fi
 
       - name: Send Slack Notification
-        if: env.SLACK_WEBHOOK_URL != ''
+        if: steps.fetch-slack.outputs.has_webhook == 'true'
         run: |
           curl -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-type: application/json' \

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Fetch secrets from GCP Secret Manager
         id: fetch-secrets
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           echo "Fetching secrets from GCP Secret Manager..."
           
@@ -263,7 +263,7 @@ jobs:
 
       - name: Fetch secrets from GCP Secret Manager
         id: fetch-secrets
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           API_KEY=$(gcloud secrets versions access latest --secret="api-key" --project=llmhive-orchestrator 2>/dev/null || echo "")
           if [ -n "$API_KEY" ]; then

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,6 +35,10 @@ jobs:
     name: Run Smoke Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
+      id-token: write
     
     # Only run if workflow_run succeeded (or if triggered manually/scheduled)
     if: |
@@ -232,6 +236,9 @@ jobs:
     name: Quality Benchmark Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     
     # Only run if full smoke tests passed
     needs: [smoke-tests]

--- a/.github/workflows/weekly-improvement.yml
+++ b/.github/workflows/weekly-improvement.yml
@@ -28,6 +28,8 @@ jobs:
     
     permissions:
       contents: write
+      id-token: write
+      issues: write
       pull-requests: write
     
     steps:

--- a/.github/workflows/weekly-improvement.yml
+++ b/.github/workflows/weekly-improvement.yml
@@ -67,7 +67,7 @@ jobs:
       
       - name: Fetch secrets from GCP Secret Manager
         id: fetch-secrets
-        if: steps.gcp-auth.outcome == 'success'
+        if: steps['gcp-auth'].outcome == 'success'
         run: |
           echo "Fetching secrets from GCP Secret Manager..."
           

--- a/artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md
+++ b/artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md
@@ -1,0 +1,103 @@
+# Benchmark Key Rotation Runbook
+
+Date: `2026-04-02`
+
+## Goal
+
+Rotate the previously exposed benchmark/backend API key with minimal launch risk.
+
+## Current Wiring
+
+Backend:
+- Cloud Run env `API_KEY` is sourced from Secret Manager secret `api-key` using `latest`.
+
+Frontend/server routes:
+- Vercel server routes use `LLMHIVE_API_KEY` when proxying to the backend.
+- This means Vercel and Cloud Run must agree on the same key value during and after rotation.
+
+Known frontend/server routes depending on `LLMHIVE_API_KEY`:
+- `app/api/chat/route.ts`
+- `app/api/execute/route.ts`
+- `app/api/projects/route.ts`
+- `app/api/conversations/route.ts`
+- `app/api/openrouter/models/route.ts`
+- `app/api/openrouter/rankings/route.ts`
+- `app/api/billing/subscription/route.ts`
+- `app/api/billing/portal/route.ts`
+- `app/api/billing/verify-session/route.ts`
+- `app/api/billing/cancel/route.ts`
+- `app/api/billing/usage/route.ts`
+
+GitHub Actions:
+- Scheduled benchmark workflow fetches the same Secret Manager secret `api-key` through Workload Identity.
+
+## Hard Rule
+
+Do not rotate `api-key` in Google Secret Manager until Vercel access is restored and `LLMHIVE_API_KEY` can be updated safely.
+
+If the backend key changes before Vercel is updated, production server routes on the frontend will begin sending the wrong `X-API-Key` header to Cloud Run.
+
+## Safe Rotation Procedure
+
+1. Restore Vercel access.
+   - Confirm you can edit production environment variables for the deployed frontend project.
+   - Confirm `LLMHIVE_API_KEY` exists in Vercel production env.
+
+2. Generate a new strong key value.
+   - Keep the old value available until verification completes.
+
+3. Add a new Secret Manager version for `api-key`.
+   - Do not delete the old version yet.
+
+4. Update Vercel production env `LLMHIVE_API_KEY` to the new value.
+   - Redeploy the frontend if Vercel does not hot-apply server env changes.
+
+5. Roll a new Cloud Run revision so the backend picks up the new `latest` secret value deterministically.
+   - Because the service references `api-key:latest`, a new revision is the safest way to ensure the container actually loads the new value.
+
+6. Verify production manually.
+   - `https://www.llmhive.ai/sign-in` still loads.
+   - Authenticated app routes still work.
+   - Backend chat with the new key returns `200`.
+   - Frontend server routes that proxy to backend still work.
+
+7. Verify GitHub Actions secret fetch path.
+   - Re-run the scheduled benchmark workflow in a verification-only path or use equivalent secret-fetch validation.
+   - Confirm the workflow still fetches `api-key` successfully via Workload Identity.
+   - If GCP auth succeeds but the fetch step is skipped, treat that as a workflow bug and do not count it as successful WIF validation.
+   - Preferred low-risk path: dispatch `Scheduled Benchmarks` with `mode=secrets_only`, `test_target=production`, and `enable_external=false` so the workflow verifies `api-key` retrieval without executing benchmark suites.
+
+8. Revoke the old key.
+   - Only after frontend, backend, and workflow validation all pass.
+   - Disable any malformed intermediate versions as well; only the final good version should remain enabled.
+
+## Suggested Verification Checks
+
+Backend direct check:
+
+```bash
+curl -sS "https://llmhive-orchestrator-7h6b36l7ta-ue.a.run.app/v1/chat" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: NEW_KEY" \
+  -d '{"prompt":"What is 2 + 2?","model":"auto","tier":"elite"}'
+```
+
+Secret fetch check:
+
+```bash
+gcloud secrets versions access latest --secret="api-key" --project="llmhive-orchestrator"
+```
+
+Cloud Run revision check:
+
+```bash
+gcloud run services describe llmhive-orchestrator --region us-east1 --format=json
+```
+
+## Current Blocker
+
+The runtime rotation is now executable from this machine because Vercel access has been restored.
+
+Remaining blocker:
+- GitHub workflow verification is currently imperfect because several workflows authenticate to Google Cloud successfully but still skip their Secret Manager fetch step.
+- Until that workflow gating issue is fixed, use direct runtime checks plus explicit GitHub secret alignment as mitigation, and treat end-to-end WIF validation as still pending.

--- a/artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md
+++ b/artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md
@@ -100,4 +100,5 @@ The runtime rotation is now executable from this machine because Vercel access h
 
 Remaining blocker:
 - GitHub workflow verification is currently imperfect because several workflows authenticate to Google Cloud successfully but still skip their Secret Manager fetch step.
+- Root cause from branch verification: those jobs lacked `id-token: write`, so GitHub never injected OIDC token request variables for `google-github-actions/auth`.
 - Until that workflow gating issue is fixed, use direct runtime checks plus explicit GitHub secret alignment as mitigation, and treat end-to-end WIF validation as still pending.

--- a/artifacts/launch_freeze/launch_readiness_audit_20260402.md
+++ b/artifacts/launch_freeze/launch_readiness_audit_20260402.md
@@ -1,0 +1,163 @@
+# Launch Readiness Audit
+
+Date: `2026-04-02`
+
+## Freeze Decision
+
+- Production should be treated as frozen for launch.
+- Do not run new broad orchestration changes on the production path.
+- If more benchmark or routing improvements are desired, do them on a separate `v2` branch after launch.
+
+## Locked Claim Basis
+
+Approved benchmark basis for all market-facing assets:
+- Free certification: `benchmark_reports/category_benchmarks_free_20260331.json`
+- Elite certification: `benchmark_reports/category_benchmarks_elite_20260401.json`
+- Leader references: `benchmark_configs/category_leaders_llmhive.json` (`version=2026-03-29`)
+
+Notes:
+- `RAG` must stay in native `MRR@10` format (`0.497`, `0.554`, `0.420`), not percentage accuracy.
+- `Dialogue` cost telemetry is still not audit-grade and must not be described as confirmed zero spend.
+
+## Live Production Identity
+
+Backend service:
+- Cloud Run service: `llmhive-orchestrator`
+- Live URL: `https://llmhive-orchestrator-7h6b36l7ta-ue.a.run.app`
+- Latest ready revision: `llmhive-orchestrator-02204-lzb`
+- Previous ready revision: `llmhive-orchestrator-02203-grk`
+
+Observed live backend status:
+- `/health`: `200`
+- `/build-info`: `200`, commit now exposed as `b9c27bf7-c825-485b-a914-e527b4dfa029`
+- `/v1/chat` Free request: `200`
+- `/v1/chat` Elite request: `200`
+
+## Smoke Pass Summary
+
+Public frontend routes checked:
+- `https://llmhive.vercel.app/landing` -> `200`
+- `https://llmhive.vercel.app/pricing` -> `200`
+- `https://llmhive.vercel.app/privacy` -> `200`
+- `https://llmhive.vercel.app/terms` -> `200`
+- `https://llmhive.vercel.app/contact` -> `200`
+- `https://www.llmhive.ai/sign-in` -> `200`, Clerk sign-in form renders
+- `https://www.llmhive.ai/` -> `200` -> redirects into working sign-in flow
+
+App entry routes checked:
+- `https://llmhive.vercel.app/` -> redirects into sign-in flow
+- `https://llmhive.vercel.app/models` -> redirects into sign-in flow
+- `https://llmhive.vercel.app/orchestration` -> redirects into sign-in flow
+- `https://llmhive.vercel.app/settings` -> redirects into sign-in flow
+
+Observed hostname/auth mismatch:
+- The canonical launch domain `https://www.llmhive.ai` works with Clerk.
+- The public Vercel hostname `https://llmhive.vercel.app` previously triggered Clerk `origin_invalid` on `https://clerk.llmhive.ai/v1/client`.
+- After the controlled Vercel deploy, `https://llmhive.vercel.app/sign-in` now returns `308` to `https://www.llmhive.ai/sign-in`, so Clerk only runs on the canonical domain.
+
+Observed backend/preflight drift:
+- Production preflight tooling was updated to understand the current `extra.tier_info` + `extra.cost_tracking` telemetry shape, so paid/free telemetry checks now pass cleanly against live production.
+- After the controlled backend deploy from the isolated release worktree, `/build-info` now exposes commit and build time, and `/internal/launch_kpis` responds with the internal key.
+- After Vercel access was restored and a controlled frontend deploy completed, the canonical redirect behavior is now live.
+
+Latest refined preflight result:
+- Paid/free tier telemetry checks: PASS
+- Backend verification after deploy: PASS (`health`, `build_info`, `launch_kpis`)
+- Frontend verification after deploy: PASS (`vercel_redirect`, `canonical_sign_in`)
+- Remaining informational-only note: raw HTTP probe for `canonical_root_redirect` can still time out
+
+Latest minimal-release verifier baseline:
+- `vercel_redirect`: PASS (`308` to `https://www.llmhive.ai/sign-in`)
+- `canonical_sign_in`: PASS
+- `backend_health`: PASS
+- `build_info`: PASS (`commit=b9c27bf7-c825-485b-a914-e527b4dfa029`)
+- `launch_kpis`: PASS (`200` with internal key)
+- `canonical_root_redirect`: informational-only; plain HTTP probes still time out even though browser verification reached the sign-in flow
+
+Latest release-candidate safety finding:
+- Cloud Run revision `llmhive-orchestrator-02204-lzb` is now live at 100% traffic from Cloud Build `b9c27bf7-c825-485b-a914-e527b4dfa029`.
+- The backend metadata and internal KPI drift were resolved by the controlled backend deploy from the isolated release worktree.
+- Vercel production deployment `https://llmhive-3cc5fuma6-camilo-diazs-projects-84a2ae74.vercel.app` is live and aliases `https://www.llmhive.ai` plus `https://llmhive.vercel.app`.
+- The first frontend deploy attempt failed before going live because of a pre-existing TypeScript contract mismatch in `hooks/use-model-registry.ts`; that was fixed in the safe worktree and the retry deploy succeeded.
+- The first isolated release candidate from `release/eliteplus-certified` must not be deployed: compared with the current committed benchmark-prep branch, it diverges in benchmark-critical files including `scripts/run_category_benchmarks.py`, `llmhive/src/llmhive/app/benchmarks/runner_llmhive.py`, and `tests/benchmarks/test_runner_llmhive_contract.py`.
+- A safer replacement candidate was recut from committed SHA `c1c136c58122963681f2961ee4dd8a040f62f239` into `/Users/camilodiaz/LLMHIVE-market-release-current`.
+- In that fresh worktree, the live fixes were applied and validated without touching benchmark-critical files.
+
+## Benchmark Key Rotation Status
+
+Current state:
+- Cloud Run reads `API_KEY` from Secret Manager secret `api-key` using `latest`.
+- Secret Manager version `3` is now the only enabled `api-key` version.
+- Old exposed version `1` and malformed version `2` have both been disabled.
+- Vercel `LLMHIVE_API_KEY` was updated across production, preview, and development, and the frontend was redeployed successfully.
+- Cloud Run was rolled to revision `llmhive-orchestrator-02206-cct` so the backend picked up `api-key:latest`.
+- A protected backend endpoint (`/v1/analyze/file`) accepts the new key and rejects the old key (`200` vs `401`).
+- The GitHub Actions repository secret `API_KEY` now exists again and has been aligned to the rotated value.
+
+Blocker:
+- Runtime key rotation itself is complete.
+- Residual CI/CD issue: multiple GitHub workflows authenticate to Google Cloud successfully but still skip their Secret Manager fetch step, so Workload Identity secret retrieval is not yet proven end-to-end by workflow execution.
+- A workflow-only condition fix has been prepared locally in `.github/workflows/smoke-tests.yml`, `.github/workflows/quality-regression.yml`, `.github/workflows/scheduled-benchmarks.yml`, and `.github/workflows/weekly-improvement.yml`, but GitHub cannot use that fix until it is committed and pushed.
+- `scheduled-benchmarks.yml` manual verification run `23927096244` failed with `401` because it never populated `LLMHIVE_API_KEY`; the benchmark secret-fetch step was skipped.
+- `smoke-tests.yml` manual verification run `23927210730` succeeded overall, but both jobs also skipped the Secret Manager fetch step even after successful GCP auth.
+- Detailed procedure: `artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md`
+
+Safe rotation sequence:
+1. Fix the GitHub workflow condition/gating bug so the GCP secret-fetch steps actually run after auth.
+2. Re-run a workflow that explicitly fetches `api-key` from Secret Manager and confirm the step executes.
+   - Preferred low-risk path: dispatch `Scheduled Benchmarks` with `mode=secrets_only`, `test_target=production`, and `enable_external=false` so the workflow verifies secret retrieval without running benchmark suites.
+3. Keep version `3` as the active runtime key unless a further rotation is required.
+
+## Rollback Procedure
+
+Known live revision:
+- `llmhive-orchestrator-02206-cct`
+
+Known previous ready revision:
+- `llmhive-orchestrator-02205-qx5`
+
+One-command backend rollback:
+
+```bash
+gcloud run services update-traffic llmhive-orchestrator --region us-east1 --to-revisions llmhive-orchestrator-02205-qx5=100
+```
+
+One-command frontend rollback:
+
+```bash
+vercel rollback https://llmhive-kvch9npn6-camilo-diazs-projects-84a2ae74.vercel.app --scope camilo-diazs-projects-84a2ae74 --yes
+```
+
+## Launch Operations Basics
+
+Verified present:
+- Pricing page
+- Contact page
+- Privacy page
+- Terms page
+- Vercel analytics wrapper in production layout
+- Optional GA and Meta Pixel hooks in layout
+
+Still needs explicit human confirmation before launch:
+- Pricing/package details are final
+- Support ownership and response path are assigned
+- KPI dashboards and alert routing are being watched by named owners
+- Launch checklist ownership is assigned, not just documented
+
+## Launch Blockers
+
+P0 blockers before launch:
+- Resolve the GitHub workflow secret-fetch gating bug so Workload Identity retrieval of `api-key` is actually exercised and not silently skipped.
+- Rotate the previously exposed benchmark API key after Vercel env access is restored.
+- Refresh live version/monitoring visibility so `build-info` and KPI checks reflect the running release accurately.
+
+P1 cleanup before publishing claims:
+- Keep all benchmark assets on the same locked artifact basis.
+- Do not mix `MRR@10` decimals with percentage formatting across tables.
+
+Release scoping note:
+- Minimal safe release surface is documented in `artifacts/launch_freeze/minimal_release_surface_20260402.md`.
+- Exact clean-branch release commands are documented in `artifacts/launch_freeze/minimal_release_commands_20260402.md`.
+- Isolated release-candidate handoff is documented in `artifacts/launch_freeze/minimal_release_handoff_20260402.md`.
+- Static benchmark-isolation verifier: `scripts/verify_market_release_isolation.py` (`passed: true`)
+- Safe local no-regression gate: `python scripts/run_market_release_gate.py --json` (`passed: true`)

--- a/artifacts/launch_freeze/launch_readiness_audit_20260402.md
+++ b/artifacts/launch_freeze/launch_readiness_audit_20260402.md
@@ -100,6 +100,7 @@ Blocker:
 - A workflow-only condition fix has been prepared locally in `.github/workflows/smoke-tests.yml`, `.github/workflows/quality-regression.yml`, `.github/workflows/scheduled-benchmarks.yml`, and `.github/workflows/weekly-improvement.yml`, but GitHub cannot use that fix until it is committed and pushed.
 - `scheduled-benchmarks.yml` manual verification run `23927096244` failed with `401` because it never populated `LLMHIVE_API_KEY`; the benchmark secret-fetch step was skipped.
 - `smoke-tests.yml` manual verification run `23927210730` succeeded overall, but both jobs also skipped the Secret Manager fetch step even after successful GCP auth.
+- Root cause confirmed from live branch verification: the affected jobs were missing `id-token: write`, so `google-github-actions/auth` could not receive GitHub OIDC token variables and Secret Manager fetch steps were skipped afterward.
 - Detailed procedure: `artifacts/launch_freeze/benchmark_key_rotation_runbook_20260402.md`
 
 Safe rotation sequence:

--- a/artifacts/launch_freeze/secret_source_of_truth_map_20260402.md
+++ b/artifacts/launch_freeze/secret_source_of_truth_map_20260402.md
@@ -1,0 +1,144 @@
+# Secret Source Of Truth Map
+
+Date: `2026-04-02`
+
+## Goal
+
+Define which platform owns which class of secret so launch operations do not drift across Google Cloud, Vercel, and GitHub.
+
+## Current Secret Planes
+
+### Google Secret Manager
+
+Primary runtime source of truth for backend secrets used by Cloud Run.
+
+Examples currently present:
+- `api-key`
+- `openai-api-key`
+- `anthropic-api-key`
+- `grok-api-key`
+- `gemini-api-key`
+- `deepseek-api-key`
+- `open-router-key`
+- `pinecone-api-key`
+- `pinecone-host-*`
+- `stripe-*`
+- `clerk-secret-key`
+- `slack-webhook-url`
+- `resend-api-key`
+- `llmhive-internal-admin-override-key`
+
+### Vercel Environment Variables
+
+Source of truth for frontend/server-route secrets and frontend-facing configuration that Vercel must know at runtime.
+
+Production env names currently present:
+- `LLMHIVE_API_KEY`
+- `CLERK_SECRET_KEY`
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+- `NEXT_PUBLIC_CLERK_SIGN_IN_URL`
+- `NEXT_PUBLIC_CLERK_SIGN_UP_URL`
+- `NEXT_PUBLIC_API_BASE_URL`
+- `ORCHESTRATOR_API_BASE_URL`
+- `AUTH_SECRET`
+- `GITHUB_SECRET`
+- `GITHUB_ID`
+
+### GitHub Secrets
+
+Source of truth for workflow authentication and workflow-only fallback values.
+
+Repo secrets currently present:
+- `API_KEY`
+- `CLERK_SECRET_KEY`
+- `GCP_PROJECT_ID`
+- `GCP_SA_KEY`
+- `GEMINI_API_KEY`
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+- `WIF_PROVIDER`
+- `WIF_SERVICE_ACCOUNT`
+
+## Ownership Rules
+
+### Google should own
+
+All backend/runtime secrets that Cloud Run loads directly:
+- provider API keys
+- `API_KEY`
+- Pinecone secrets
+- Stripe server secrets
+- internal admin keys
+- webhook URLs
+- resend/slack/server-only integrations
+
+Rule:
+- If Cloud Run needs it, Google Secret Manager is the canonical source.
+
+### Vercel should own
+
+Only values required by the Next.js frontend or Vercel server routes:
+- `LLMHIVE_API_KEY`
+- frontend auth config
+- frontend publishable keys
+- backend base URLs
+- server-route integration config that only Vercel executes
+
+Rule:
+- If Next.js server routes need it at request time, Vercel must have a copy.
+- When the secret mirrors a Google runtime secret, rotation must update Vercel immediately after Google.
+
+### GitHub should own
+
+Workflow auth and workflow-only config:
+- `WIF_PROVIDER`
+- `WIF_SERVICE_ACCOUNT`
+- `GCP_PROJECT_ID`
+- `GCP_SA_KEY` only if still required as fallback
+
+Conditional fallback:
+- `API_KEY` exists now because some workflows still reference `secrets.API_KEY`.
+
+Rule:
+- GitHub should not be the primary source of runtime secrets when Workload Identity + Secret Manager can fetch them.
+- Keep a GitHub copy only when a workflow still depends on it or while migrating off legacy secret references.
+
+## Current Drift Risks
+
+### Intentional mirrored secret
+
+`API_KEY` / `LLMHIVE_API_KEY`
+- Google Secret Manager `api-key` is the backend source.
+- Vercel `LLMHIVE_API_KEY` must match so server routes can proxy to backend.
+- GitHub `API_KEY` currently exists as workflow compatibility support.
+
+### Legacy GitHub secret references
+
+`ci-cd.yaml` still references `secrets.API_KEY`.
+
+Impact:
+- Even after runtime rotation was completed safely, workflows may still consume GitHub-hosted values unless migrated fully to Secret Manager fetches.
+
+### Workflow fetch gating
+
+Several workflows authenticate to Google Cloud successfully but still skip their Secret Manager fetch step during GitHub execution.
+
+Impact:
+- Runtime is healthy.
+- End-to-end WIF-based secret retrieval is not yet proven by workflow execution.
+
+## Recommended End State
+
+1. Keep Google Secret Manager as the canonical backend secret store.
+2. Keep Vercel env only for frontend/server-route secrets and mirrored backend auth where required.
+3. Reduce GitHub secrets to workflow auth plus temporary compatibility fallbacks.
+4. Migrate workflows away from `secrets.API_KEY` where possible and prefer:
+   - auth to Google
+   - fetch from Secret Manager
+   - fail clearly if fetch did not run
+
+## Immediate Next Steps
+
+1. Commit and push the workflow-only condition fix so GitHub runs the corrected workflow definitions.
+2. Re-run a workflow that fetches `api-key` from Secret Manager and confirm the fetch step actually executes.
+3. Decide whether to keep `API_KEY` in GitHub as a temporary fallback or remove that dependency from `ci-cd.yaml`.
+4. Record final ownership for pricing, support, and dashboard watchers before launch.


### PR DESCRIPTION
## Summary
- fix GitHub Actions secret-fetch gating by using the correct step outcome syntax and adding missing OIDC `id-token: write` permissions to auth-using jobs
- add a `secrets_only` mode to `Scheduled Benchmarks` so Secret Manager retrieval can be verified without executing benchmark suites
- document the confirmed OIDC root cause, rotation state, and secret ownership plan in launch freeze artifacts

## Test plan
- [x] Dispatch `Scheduled Benchmarks` on the branch with `mode=secrets_only`, `test_target=production`, `enable_external=false`
- [x] Confirm `Authenticate to Google Cloud`, `Fetch benchmark API key from GCP Secret Manager`, and `Verify production secret wiring only` all succeed while benchmark steps remain skipped
- [x] Dispatch `Production Smoke Tests` on the branch and confirm the smoke and quality jobs both reach successful Secret Manager fetch steps
- [x] Keep production unchanged; do not rerun full benchmark certification suites


Made with [Cursor](https://cursor.com)