### PR TITLE
fix(smoke): enable /v1/chat smoke + 55s latency check

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -87,6 +87,16 @@ jobs:
           else
             echo "::warning::api-key not found in Secret Manager"
           fi
+
+          # Scheduled benchmark secret — bypasses paid-subscription gate on /v1/chat (same as scheduled-benchmarks.yml)
+          BENCH_SECRET=$(gcloud secrets versions access latest --secret="scheduled-benchmark-secret" --project=llmhive-orchestrator 2>/dev/null || echo "")
+          if [ -n "$BENCH_SECRET" ]; then
+            echo "::add-mask::$BENCH_SECRET"
+            echo "LLMHIVE_SCHEDULED_BENCHMARK_SECRET=$BENCH_SECRET" >> $GITHUB_ENV
+            echo "✅ Retrieved scheduled-benchmark-secret from Secret Manager"
+          else
+            echo "::warning::scheduled-benchmark-secret not found; chat smoke needs SMOKE_TEST_USER_ID repo secret"
+          fi
           
           # Slack webhook URL for failure notifications
           SLACK_URL=$(gcloud secrets versions access latest --secret="slack-webhook-url" --project=llmhive-orchestrator 2>/dev/null || echo "")
@@ -113,6 +123,8 @@ jobs:
           PRODUCTION_URL: ${{ steps.url.outputs.url }}
           SMOKE_TIMEOUT: '60'
           SMOKE_CHAT_MAX_MS: '55000'
+          LLMHIVE_SCHEDULED_BENCHMARK_SECRET: ${{ env.LLMHIVE_SCHEDULED_BENCHMARK_SECRET }}
+          SMOKE_TEST_USER_ID: ${{ secrets.SMOKE_TEST_USER_ID }}
         run: |
           echo "Running smoke tests against: $PRODUCTION_URL"
           pytest tests/smoke/ \
@@ -336,6 +348,12 @@ jobs:
             echo "QUALITY_TEST_API_KEY=$API_KEY" >> $GITHUB_ENV
           fi
 
+          BENCH_SECRET=$(gcloud secrets versions access latest --secret="scheduled-benchmark-secret" --project=llmhive-orchestrator 2>/dev/null || echo "")
+          if [ -n "$BENCH_SECRET" ]; then
+            echo "::add-mask::$BENCH_SECRET"
+            echo "LLMHIVE_SCHEDULED_BENCHMARK_SECRET=$BENCH_SECRET" >> $GITHUB_ENV
+          fi
+
       - name: Determine production URL
         id: url
         run: |
@@ -349,6 +367,8 @@ jobs:
         id: quality
         env:
           PRODUCTION_URL: ${{ steps.url.outputs.url }}
+          LLMHIVE_SCHEDULED_BENCHMARK_SECRET: ${{ env.LLMHIVE_SCHEDULED_BENCHMARK_SECRET }}
+          SMOKE_TEST_USER_ID: ${{ secrets.SMOKE_TEST_USER_ID }}
         run: |
           echo "Running quality benchmarks against: $PRODUCTION_URL"
           pytest tests/smoke/test_quality_benchmark.py \

--- a/artifacts/launch_freeze/v1_chat_latency_launch_decision.md
+++ b/artifacts/launch_freeze/v1_chat_latency_launch_decision.md
@@ -19,7 +19,9 @@ Status: **Launch-acceptable with monitoring**
 
 ## What we did (no runtime routing change)
 
-- Smoke tests record chat latency and assert the **55s** budget on successful simple chat (`tests/smoke/test_production.py`).
+- Smoke tests send `api-key` + `X-LLMHIVE-Scheduled-Benchmark-Secret` (from GCP `scheduled-benchmark-secret`, same as scheduled benchmarks) so `/v1/chat` returns 200 in CI.
+- Optional fallback: `SMOKE_TEST_USER_ID` repo secret → `metadata.user_id` for a paid subscriber.
+- On 200, smoke asserts the **55s** budget (`tests/smoke/test_production.py`).
 - Failed smoke runs upload Cloud Run `/v1/chat` latency diagnostics (`.github/workflows/smoke-tests.yml`).
 
 ## What we did not change (avoid regressions)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -27,6 +27,9 @@ HEALTH_PROBE_PATHS = ("/health", "/_ah/health")
 HEALTH_PROBE_RETRIES = 3
 HEALTH_PROBE_RETRY_DELAY_S = 2.0
 
+# Same header as llmhive.app.billing.scheduled_benchmark (production CI benchmarks).
+SCHEDULED_BENCHMARK_HEADER = "X-LLMHIVE-Scheduled-Benchmark-Secret"
+
 
 def probe_health_endpoint(
     session: requests.Session,
@@ -83,6 +86,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=os.environ.get("SMOKE_CHAT_MAX_MS", "55000"),
         help="Max allowed /v1/chat latency in ms for launch smoke (below request timeout)",
     )
+    parser.addoption(
+        "--smoke-user-id",
+        action="store",
+        default=os.environ.get("SMOKE_TEST_USER_ID", ""),
+        help="Clerk user_id for /v1/chat paid-subscription gate (metadata.user_id)",
+    )
 
 
 @dataclass
@@ -92,7 +101,13 @@ class SmokeTestConfig:
     api_key: str
     timeout: int
     chat_max_ms: int
-    
+    smoke_user_id: str = ""
+    scheduled_benchmark_secret: str = ""
+
+    def can_run_paid_chat(self) -> bool:
+        """True when /v1/chat can pass the paid-subscription gate."""
+        return bool(self.scheduled_benchmark_secret or self.smoke_user_id)
+
     @property
     def headers(self) -> dict:
         """Get default headers for requests."""
@@ -103,7 +118,35 @@ class SmokeTestConfig:
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
             headers["X-API-Key"] = self.api_key
+        if self.scheduled_benchmark_secret:
+            headers[SCHEDULED_BENCHMARK_HEADER] = self.scheduled_benchmark_secret
         return headers
+
+
+def build_smoke_chat_payload(smoke_config: SmokeTestConfig, **fields: object) -> dict:
+    """Build /v1/chat JSON with optional metadata.user_id for paid gate."""
+    payload = dict(fields)
+    if smoke_config.smoke_user_id:
+        meta = dict(payload.get("metadata") or {})
+        meta.setdefault("user_id", smoke_config.smoke_user_id)
+        payload["metadata"] = meta
+    return payload
+
+
+def require_chat_smoke_gate(smoke_config: SmokeTestConfig) -> None:
+    """Skip chat tests when neither benchmark bypass nor user_id is configured."""
+    if not smoke_config.can_run_paid_chat():
+        pytest.skip(
+            "Chat smoke needs LLMHIVE_SCHEDULED_BENCHMARK_SECRET "
+            "(GCP scheduled-benchmark-secret) or SMOKE_TEST_USER_ID"
+        )
+
+
+def assert_chat_latency(chat_timer: "ResponseTimer", smoke_config: SmokeTestConfig) -> None:
+    assert chat_timer.duration_ms <= smoke_config.chat_max_ms, (
+        f"Chat latency {chat_timer.duration_ms:.0f}ms exceeds launch budget "
+        f"{smoke_config.chat_max_ms}ms"
+    )
 
 
 @pytest.fixture(scope="session")
@@ -113,18 +156,26 @@ def smoke_config(request: pytest.FixtureRequest) -> SmokeTestConfig:
     api_key = request.config.getoption("--api-key")
     timeout = int(request.config.getoption("--smoke-timeout"))
     chat_max_ms = int(request.config.getoption("--smoke-chat-max-ms"))
-    
-    logger.info(f"Smoke test configuration:")
+    smoke_user_id = (request.config.getoption("--smoke-user-id") or "").strip()
+    bench_secret = os.environ.get("LLMHIVE_SCHEDULED_BENCHMARK_SECRET", "").strip()
+
+    logger.info("Smoke test configuration:")
     logger.info(f"  Base URL: {base_url}")
     logger.info(f"  API Key: {'***' + api_key[-4:] if api_key else 'Not provided'}")
     logger.info(f"  Timeout: {timeout}s")
     logger.info(f"  Chat max latency: {chat_max_ms}ms")
-    
+    logger.info(
+        f"  Chat gate: benchmark_secret={'yes' if bench_secret else 'no'}, "
+        f"user_id={'set' if smoke_user_id else 'not set'}"
+    )
+
     return SmokeTestConfig(
         base_url=base_url,
         api_key=api_key,
         timeout=timeout,
         chat_max_ms=chat_max_ms,
+        smoke_user_id=smoke_user_id,
+        scheduled_benchmark_secret=bench_secret,
     )
 
 

--- a/tests/smoke/test_production.py
+++ b/tests/smoke/test_production.py
@@ -20,7 +20,10 @@ from .conftest import (
     HEALTH_PROBE_PATHS,
     SmokeTestConfig,
     ResponseTimer,
+    assert_chat_latency,
+    build_smoke_chat_payload,
     probe_health_endpoint,
+    require_chat_smoke_gate,
 )
 
 logger = logging.getLogger(__name__)
@@ -222,37 +225,35 @@ class TestAuthenticatedEndpoints:
         timer: type[ResponseTimer],
     ) -> None:
         """Test simple chat completion."""
+        require_chat_smoke_gate(smoke_config)
         url = f"{smoke_config.base_url}/v1/chat"
-        
-        payload = {
-            "prompt": "Say 'Hello, smoke test!' and nothing else.",
-            "max_tokens": 50,
-            "stream": False,
-        }
-        
+
+        payload = build_smoke_chat_payload(
+            smoke_config,
+            prompt="Say 'Hello, smoke test!' and nothing else.",
+            max_tokens=50,
+            stream=False,
+        )
+
         with timer("POST /v1/chat (simple)") as chat_timer:
             response = http_client.post(
                 url,
                 json=payload,
                 timeout=smoke_config.timeout,
             )
-        
+
         if response.status_code == 200:
             data = response.json()
             assert "message" in data or "content" in data or "response" in data, \
                 f"Unexpected chat response format: {list(data.keys())}"
-            assert chat_timer.duration_ms <= smoke_config.chat_max_ms, (
-                f"Chat latency {chat_timer.duration_ms:.0f}ms exceeds launch budget "
-                f"{smoke_config.chat_max_ms}ms (see artifacts/launch_freeze/"
-                f"v1_chat_latency_launch_decision.md)"
-            )
-            logger.info(f"✅ Chat completion successful")
+            assert_chat_latency(chat_timer, smoke_config)
+            logger.info("✅ Chat completion successful")
             logger.info(f"   Response: {str(data)[:200]}...")
             logger.info(f"   Latency: {chat_timer.duration_ms:.0f}ms")
         elif response.status_code in (401, 402):
-            pytest.skip(
-                f"Chat smoke skipped: {response.status_code} "
-                "(auth or subscription required for smoke API key)"
+            pytest.fail(
+                f"Chat smoke failed: {response.status_code} {response.text[:200]} "
+                "(check api-key + scheduled-benchmark-secret or SMOKE_TEST_USER_ID)"
             )
         elif response.status_code == 429:
             logger.warning("⚠️  Rate limited - try again later")
@@ -267,34 +268,37 @@ class TestAuthenticatedEndpoints:
         timer: type[ResponseTimer],
     ) -> None:
         """Test chat with orchestration settings."""
+        require_chat_smoke_gate(smoke_config)
         url = f"{smoke_config.base_url}/v1/chat"
-        
-        payload = {
-            "prompt": "What is 2 + 2?",
-            "reasoning_mode": "standard",
-            "domain_pack": "default",
-            "agent_mode": "single",
-            "max_tokens": 100,
-            "stream": False,
-        }
-        
-        with timer("POST /v1/chat (orchestrated)"):
+
+        payload = build_smoke_chat_payload(
+            smoke_config,
+            prompt="What is 2 + 2?",
+            reasoning_mode="standard",
+            domain_pack="default",
+            agent_mode="single",
+            max_tokens=100,
+            stream=False,
+        )
+
+        with timer("POST /v1/chat (orchestrated)") as chat_timer:
             response = http_client.post(
                 url,
                 json=payload,
                 timeout=smoke_config.timeout,
             )
-        
+
         if response.status_code == 200:
             data = response.json()
-            logger.info(f"✅ Orchestrated chat successful")
-            # Check for orchestration metadata
+            assert_chat_latency(chat_timer, smoke_config)
+            logger.info("✅ Orchestrated chat successful")
             if "models_used" in data or "extra" in data:
-                logger.info(f"   Orchestration metadata present")
+                logger.info("   Orchestration metadata present")
+            logger.info(f"   Latency: {chat_timer.duration_ms:.0f}ms")
         elif response.status_code in (401, 402):
-            pytest.skip(
-                f"Orchestrated chat smoke skipped: {response.status_code} "
-                "(auth or subscription required for smoke API key)"
+            pytest.fail(
+                f"Orchestrated chat smoke failed: {response.status_code} "
+                f"{response.text[:200]}"
             )
         elif response.status_code == 429:
             logger.warning("⚠️  Rate limited - try again later")

--- a/tests/smoke/test_quality_benchmark.py
+++ b/tests/smoke/test_quality_benchmark.py
@@ -15,7 +15,12 @@ from typing import Any, Dict, List
 import pytest
 import requests
 
-from .conftest import SmokeTestConfig, ResponseTimer
+from .conftest import (
+    SmokeTestConfig,
+    ResponseTimer,
+    build_smoke_chat_payload,
+    require_chat_smoke_gate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,18 +131,18 @@ class TestQualityBenchmarks:
         timer: type[ResponseTimer],
     ) -> None:
         """Test individual quality benchmark."""
+        require_chat_smoke_gate(smoke_config)
         url = f"{smoke_config.base_url}/v1/chat"
-        
-        payload = {
-            "prompt": benchmark["prompt"],
-            "reasoning_mode": "standard",
-            "domain_pack": "default",
-            "max_tokens": 500,
-            "stream": False,
-            "orchestration": {
-                "accuracy_level": 3,
-            },
-        }
+
+        payload = build_smoke_chat_payload(
+            smoke_config,
+            prompt=benchmark["prompt"],
+            reasoning_mode="standard",
+            domain_pack="default",
+            max_tokens=500,
+            stream=False,
+            orchestration={"accuracy_level": 3},
+        )
         
         test_id = benchmark["id"]
         category = benchmark["category"]
@@ -155,9 +160,9 @@ class TestQualityBenchmarks:
         # Check response status
         if response.status_code != 200:
             if response.status_code in (401, 402, 403):
-                pytest.skip(
-                    f"Chat quality check skipped: {response.status_code} "
-                    "(auth or subscription required for smoke API key)"
+                pytest.fail(
+                    f"Chat quality check failed: {response.status_code} "
+                    f"{response.text[:200]}"
                 )
             elif response.status_code == 429:
                 pytest.skip("Rate limited")
@@ -202,20 +207,22 @@ class TestQualityBenchmarks:
         timer: type[ResponseTimer],
     ) -> None:
         """Verify we never return empty responses."""
+        require_chat_smoke_gate(smoke_config)
         url = f"{smoke_config.base_url}/v1/chat"
-        
+
         test_prompts = [
             "Hello, how are you?",
             "What is 2 + 2?",
             "Explain photosynthesis briefly.",
         ]
-        
+
         for prompt in test_prompts:
-            payload = {
-                "prompt": prompt,
-                "max_tokens": 100,
-                "stream": False,
-            }
+            payload = build_smoke_chat_payload(
+                smoke_config,
+                prompt=prompt,
+                max_tokens=100,
+                stream=False,
+            )
             
             with timer(f"Empty response check"):
                 response = http_client.post(


### PR DESCRIPTION
## Summary

- Smoke `/v1/chat` uses the same auth as scheduled benchmarks: GCP `api-key` + `scheduled-benchmark-secret` header (bypasses 402 subscription gate).
- Optional `secrets.SMOKE_TEST_USER_ID` → `metadata.user_id` fallback.
- Chat tests **fail** on 401/402 when gate is configured (no silent skip).
- **55s latency assert** runs on 200 responses (verified locally ~4s).

## Test plan

- [x] Local: `test_chat_completion_simple` passed with GCP secrets (~4s)
- [ ] CI Production Smoke Tests after merge

## Local repro

```bash
export API_KEY=$(gcloud secrets versions access latest --secret=api-key --project=llmhive-orchestrator)
export LLMHIVE_SCHEDULED_BENCHMARK_SECRET=$(gcloud secrets versions access latest --secret=scheduled-benchmark-secret --project=llmhive-orchestrator)
python3 -m pytest tests/smoke/test_production.py::TestAuthenticatedEndpoints::test_chat_completion_simple \
  --production-url=https://llmhive-orchestrator-792354158895.us-east1.run.app \
  --api-key="$API_KEY" --smoke-timeout=90 --smoke-chat-max-ms=55000 -v
```


Made with [Cursor](https://cursor.com)